### PR TITLE
Use resourceFromAttributes for OTLP resource Closes #63

### DIFF
--- a/github-copilot-sdk/src/telemetry.ts
+++ b/github-copilot-sdk/src/telemetry.ts
@@ -12,7 +12,7 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-proto";
 import { PeriodicExportingMetricReader, AggregationTemporality } from "@opentelemetry/sdk-metrics";
 import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base";
-import { Resource } from "@opentelemetry/resources";
+import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 import { trace, metrics, type Tracer, type Meter } from "@opentelemetry/api";
 
@@ -37,7 +37,7 @@ export function initTelemetry(): void {
   const serviceName = process.env.OTEL_SERVICE_NAME || "copilot-sdk-agent";
   const authHeader = `Api-Token ${otlpToken}`;
 
-  const resource = new Resource({
+  const resource = resourceFromAttributes({
     [ATTR_SERVICE_NAME]: serviceName,
   });
 


### PR DESCRIPTION
This pull request updates the way resources are created for OpenTelemetry in the `github-copilot-sdk/src/telemetry.ts` file. The main change is replacing the deprecated `Resource` constructor with the recommended `resourceFromAttributes` function, ensuring compatibility with newer versions of the OpenTelemetry library.

**OpenTelemetry resource initialization update:**

* Replaced usage of the deprecated `Resource` constructor with `resourceFromAttributes` for creating telemetry resources in `github-copilot-sdk/src/telemetry.ts` [[1]](diffhunk://#diff-c91b8029052673b1ca66a0c4e19916e9964c5f13f132aa9170f32daafecd4467L15-R15) [[2]](diffhunk://#diff-c91b8029052673b1ca66a0c4e19916e9964c5f13f132aa9170f32daafecd4467L40-R40)
