### PR TITLE
AI-50 add span audit report generation for e2e tests

### DIFF
--- a/.claude/commands/update-audit-profiles.md
+++ b/.claude/commands/update-audit-profiles.md
@@ -1,0 +1,86 @@
+# update-audit-profiles
+
+Update the Go profile definitions in `test/e2e/audit_test.go` to match the current `test/e2e/sdk-comparison-baseline.json`.
+
+## When to run
+
+Run whenever `sdk-comparison-baseline.json` has changed (new AR-IDs added, attributes moved between required/optional, new profiles added, equivalents/fallbacks updated).
+
+## Mapping: baseline JSON → Go code
+
+### Files involved
+
+| File | Role |
+|------|------|
+| `test/e2e/sdk-comparison-baseline.json` | Source of truth |
+| `test/e2e/audit_test.go` | Profile definitions to update |
+
+### Key baseline sections
+
+| Baseline path | Used for |
+|---------------|----------|
+| `comparison_contract.profile_selection.profiles` | Profile names, which AR-IDs are required vs optional, which profiles extend generic |
+| `comparison_contract.normalization.equivalents_any_of` | `AnyOf` lists on `AttributeCheck` (primary + canonical fallbacks) |
+| `comparison_contract.normalization.legacy_fallbacks` | Additional `AnyOf` entries (legacy attribute names accepted as fallback) |
+| `attributes[]` | Resolve AR-ID → attribute `name` |
+
+### Step-by-step
+
+1. **Read the baseline.** Parse `comparison_contract.profile_selection.profiles` to get the current required/optional AR-ID lists per profile.
+
+2. **Resolve AR-IDs to attribute names.** For each AR-ID in a profile's lists, find the matching entry in `attributes[]` by `rule_id` and take its `name` field.
+
+3. **Build `AnyOf` lists.** For each `AttributeCheck`:
+   - Check `normalization.equivalents_any_of`: if the attribute's name appears in any group there, set `AnyOf` to that entire group (primary attribute first).
+   - Check `normalization.legacy_fallbacks`: if the attribute's name is a key there, append the fallback names after the primary in `AnyOf`.
+   - If neither applies, leave `AnyOf` empty (only `Name` is checked).
+
+4. **Update `genericRequired` and `genericOptional`** to match the `generic` profile's `required_attributes` and `optional_attributes` lists exactly.
+
+5. **Update provider profile extensions** (e.g. `BedrockProfile` in the `init()` func):
+   - `additional_required_attributes` → appended to `genericRequired`
+   - `additional_optional_attributes` → appended to `genericOptional`
+   - Each profile that `extends: generic` follows this pattern.
+
+6. **Add new profiles** if new profile names appear in the baseline that have no corresponding Go var. Use the `init()` pattern already used by `BedrockProfile`.
+
+7. **Remove or rename profiles** if a profile was removed or renamed in the baseline.
+
+## Existing Go structure (reference)
+
+```
+var genericRequired = []AttributeCheck{ ... }   // generic profile required
+var genericOptional  = []AttributeCheck{ ... }   // generic profile optional
+var GenericProfile   = Profile{...}              // assembled from above
+
+var BedrockProfile Profile                       // declared at package level
+func init() {                                    // built in init to avoid slice aliasing
+    BedrockProfile = Profile{
+        Name: "bedrock",
+        Required: append(append([]AttributeCheck{}, genericRequired...),
+            // additional_required_attributes for bedrock
+        ),
+        Optional: append(append([]AttributeCheck{}, genericOptional...),
+            // additional_optional_attributes for bedrock
+        ),
+    }
+}
+```
+
+Use the same `init()` pattern for any new provider profile. Do not mutate `genericRequired`/`genericOptional` in place — always copy with `append([]AttributeCheck{}, genericRequired...)`.
+
+## What NOT to change
+
+- `evaluateCheck`, `buildReport`, `writeReport`, `buildMarkdown`, `auditSpan`, `fetchTraceSpans`, `mergeSpans` — report engine, unrelated to profile definitions.
+- The `RuleID` string format — use the exact string from the baseline `rule_id` field (e.g. `"AR-006"`). For the provider-identity pair AR-001/AR-002, keep the combined `"AR-001/AR-002"` rule ID as used in the existing code.
+- Do not add or remove Go profiles that are not backed by a profile entry in the baseline.
+
+## Verification
+
+After updating:
+
+```bash
+cd test/e2e && go build ./...
+```
+
+Must compile clean. No test run required to verify profile structure.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Upload audit reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: span-audit-reports-${{ matrix.name }}
           path: test/e2e/reports/
@@ -166,7 +166,7 @@ jobs:
 
       - name: Upload audit reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: span-audit-reports-${{ matrix.name }}
           path: test/e2e/reports/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -77,6 +77,24 @@ jobs:
           fi
           go test ./... -run "$TEST_RUN" -v -timeout 20m
 
+      - name: Write job summary
+        if: always()
+        run: |
+          for f in test/e2e/reports/*.md; do
+            [ -f "$f" ] || continue
+            echo "## $(basename "$f" .md)" >> "$GITHUB_STEP_SUMMARY"
+            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Upload audit reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: span-audit-reports-${{ matrix.name }}
+          path: test/e2e/reports/
+          retention-days: 30
+
       - name: Uninstall OneAgent
         if: always()
         run: |
@@ -135,3 +153,21 @@ jobs:
             echo "Error: TEST_RUN contains invalid characters: $TEST_RUN"; exit 1
           fi
           go test ./... -run "$TEST_RUN" -v -timeout 20m
+
+      - name: Write job summary
+        if: always()
+        run: |
+          for f in test/e2e/reports/*.md; do
+            [ -f "$f" ] || continue
+            echo "## $(basename "$f" .md)" >> "$GITHUB_STEP_SUMMARY"
+            cat "$f" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+      - name: Upload audit reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: span-audit-reports-${{ matrix.name }}
+          path: test/e2e/reports/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ node_modules/
 .next/
 tsconfig.tsbuildinfo
 next-env.d.ts
+
+# Generated e2e span audit reports (uploaded as CI artifacts; not committed)
+test/e2e/reports/*.json
+test/e2e/reports/*.md

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,0 +1,105 @@
+# E2E Tests — Local Setup
+
+End-to-end tests that start each demo app, invoke it, and assert that the expected `gen_ai.*` spans appear in Dynatrace. Tests use the [DQL query API](https://docs.dynatrace.com/docs/discover-dynatrace/references/dynatrace-api/environment-api/query) to poll for spans.
+
+## Prerequisites
+
+| Tool | Version | Required for |
+|------|---------|-------------|
+| Go | 1.22+ | running tests |
+| Python | 3.11+ | demo apps |
+| uv | 0.11+ | Python dependency management in demo apps |
+| Docker (or Colima) | any | apps that use a local OTel collector (e.g. `*/opentelemetry`) |
+| Dynatrace tenant | — | all tests |
+| Provider credentials | — | tests for the relevant provider (AWS, OpenAI, etc.) |
+
+## Environment setup
+
+Copy `.env.sample` to `.env` and fill in the values relevant to the tests you want to run:
+
+```bash
+cp .env.sample .env
+```
+
+### Always required
+
+| Variable | Description |
+|----------|-------------|
+| `DT_ENDPOINT` | Classic tenant URL, e.g. `https://abc12345.live.dynatrace.com`. Used by the OTel collector and OneAgent installer. |
+| `DT_APPS_ENDPOINT` | Platform/apps URL, e.g. `https://abc12345.apps.dynatrace.com`. Used by the DQL query client. |
+| `DT_API_TOKEN` | OAuth token with scopes: `storage:spans:read`, `storage:buckets:read`, `storage:events:read`, `storage:metrics:read`, `storage:metrics:write`, `openpipeline:traces:ingest`, `openpipeline:logs:ingest`, `openpipeline:events:ingest`, `openpipeline:metrics:ingest` |
+| `MAX_RUNS` | Number of LLM invocations per run. Set to `1` for local runs to avoid flooding Dynatrace with data. |
+| `OTEL_SERVICE_NAME` | Service name stamped on OTel spans — must match the `service.name` filter in the test's DQL query. Conventionally set to `<sdk>/<instrumentation>` (e.g. `aws-bedrock/opentelemetry`). |
+
+### Provider credentials
+
+Set the credentials for the provider under test. Leave others blank.
+
+| Provider | Variables |
+|----------|-----------|
+| AWS Bedrock | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `BEDROCK_MODEL_ID` |
+| OpenAI | `OPENAI_API_KEY` |
+| Anthropic | `ANTHROPIC_API_KEY` |
+| Mistral | `MISTRAL_API_KEY` |
+| Cohere | `COHERE_API_KEY` |
+| Groq | `GROQ_API_KEY` |
+
+## Running a single test
+
+Load the `.env` file, set `OTEL_SERVICE_NAME` to match the test, then run it:
+
+```bash
+cd test/e2e
+export $(grep -v '^#' .env | xargs)
+
+# example: aws-bedrock/opentelemetry (requires Docker/Colima for the OTel collector)
+OTEL_SERVICE_NAME=aws-bedrock/opentelemetry go test ./... -run TestAWSBedrockOpenTelemetry -v -timeout 20m
+
+# example: openai/oneagent (requires OneAgent installed)
+OTEL_SERVICE_NAME=openai/oneagent go test ./... -run TestOpenAIOneAgent -v -timeout 20m
+```
+
+`OTEL_SERVICE_NAME` follows the `<sdk>/<instrumentation>` convention and must match the DQL filter written in the test function.
+
+## What each test does
+
+1. Installs the demo app's Python dependencies (`make install` in the app directory).
+2. Starts the app (`make run`), passing through all environment variables.
+3. Sends a request to trigger an LLM call (HTTP apps POST to `localhost:8000`; CLI apps emit telemetry autonomously).
+4. Polls the Dynatrace DQL API until matching `gen_ai.*` spans appear (up to 3 minutes, polling every 15 seconds).
+5. Fetches all spans in the same trace to build a complete attribute picture.
+6. Writes an audit report to `test/e2e/reports/<sdk>-<instrumentation>.{json,md}` (gitignored).
+7. Stops the app.
+
+The test passes as long as at least one matching span is found. Missing required attributes are logged but do not fail the test — gaps are visible in the audit report verdict (`FAIL`/`PARTIAL`/`PASS`).
+
+## Audit reports
+
+After a test run, audit reports are written to `test/e2e/reports/`. They are gitignored — inspect them locally. In CI, reports are uploaded as GitHub Actions artifacts and written to the job summary.
+
+Attribute profiles (`GenericProfile`, `BedrockProfile`, …) are defined in `audit_test.go` and mirror the contracts in `sdk-comparison-baseline.json`. To update profiles after a baseline change, run `/update-audit-profiles` in Claude Code.
+
+## Instrumentation types
+
+| Instrumentation | What it tests |
+|----------------|---------------|
+| `oneagent` | Dynatrace OneAgent auto-instrumentation (requires OneAgent on the runner) |
+| `opentelemetry` | OpenTelemetry SDK + local OTel collector → Dynatrace (requires Docker) |
+| `openinference` | OpenInference instrumentation via OTel collector |
+
+## Troubleshooting
+
+**Spans not appearing within 3 minutes**
+- Check that `OTEL_SERVICE_NAME` matches the `service.name` filter in the test's DQL query.
+- Confirm the app started successfully — errors appear in test output before the poll starts.
+- For `*/opentelemetry`: confirm Docker/Colima is running; the OTel collector must be up for telemetry to reach Dynatrace.
+- Verify `DT_API_TOKEN` has all required scopes.
+
+**`required env var not set` panic**
+- `.env` was not loaded. Run `export $(grep -v '^#' .env | xargs)` before `go test`.
+
+**App runs in an infinite loop**
+- Set `MAX_RUNS=1` in `.env`.
+
+**Port 8000 already in use**
+- A previous test run's app process is still running. Kill it: `lsof -ti:8000 | xargs kill -9`.

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -1,6 +1,6 @@
 # E2E Tests — Local Setup
 
-End-to-end tests that start each demo app, invoke it, and assert that the expected `gen_ai.*` spans appear in Dynatrace. Tests use the [DQL query API](https://docs.dynatrace.com/docs/discover-dynatrace/references/dynatrace-api/environment-api/query) to poll for spans.
+End-to-end tests that start each demo app, invoke it, and assert that the expected `gen_ai.*` spans appear in Dynatrace. Tests use the [DQL query API](https://docs.dynatrace.com/docs/platform/grail/dynatrace-query-language) to poll for spans.
 
 ## Prerequisites
 

--- a/test/e2e/audit_test.go
+++ b/test/e2e/audit_test.go
@@ -292,8 +292,11 @@ func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string)
 }
 
 // fetchTraceSpans fetches all spans belonging to the same trace as anchor,
-// scoped to the same service.name. Falls back to [anchor] on any error.
-func fetchTraceSpans(t *testing.T, ctx context.Context, anchor map[string]interface{}) []map[string]interface{} {
+// scoped to the same service.name. Polls until the span count stabilizes
+// (two consecutive equal non-zero counts) so spans that arrive in Dynatrace
+// at different times are not missed. Uses a fresh 2-minute budget independent
+// of the anchor-poll context.
+func fetchTraceSpans(t *testing.T, _ context.Context, anchor map[string]interface{}) []map[string]interface{} {
 	t.Helper()
 
 	traceID, ok := anchor["trace.id"]
@@ -310,15 +313,38 @@ func fetchTraceSpans(t *testing.T, ctx context.Context, anchor map[string]interf
 		svcName, traceIDStr,
 	)
 
-	spans, err := dtClient.Execute(ctx, dql)
-	if err != nil {
-		t.Logf("warning: fetch trace spans: %v; using anchor only", err)
-		return []map[string]interface{}{anchor}
+	// Poll until the span count stabilizes (two consecutive equal non-zero counts).
+	// Fresh 2-minute budget so anchor-poll time does not reduce this window.
+	stableCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	lastCount := -1
+	var lastSpans []map[string]interface{}
+
+	for {
+		spans, err := dtClient.Execute(stableCtx, dql)
+		if err != nil {
+			t.Logf("warning: fetch trace spans: %v; using anchor only", err)
+			return []map[string]interface{}{anchor}
+		}
+
+		if len(spans) > 0 && len(spans) == lastCount {
+			t.Logf("trace spans stabilized at %d", len(spans))
+			return spans
+		}
+		lastCount = len(spans)
+		lastSpans = spans
+
+		select {
+		case <-stableCtx.Done():
+			if len(lastSpans) > 0 {
+				t.Logf("warning: trace span count did not stabilize within timeout; using %d spans", len(lastSpans))
+				return lastSpans
+			}
+			return []map[string]interface{}{anchor}
+		case <-time.After(15 * time.Second):
+		}
 	}
-	if len(spans) == 0 {
-		return []map[string]interface{}{anchor}
-	}
-	return spans
 }
 
 // mergeSpans folds multiple span records into one map: for each attribute, the

--- a/test/e2e/audit_test.go
+++ b/test/e2e/audit_test.go
@@ -1,0 +1,337 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// AttributeCheck defines one attribute to verify against a span.
+// AnyOf lists the primary attribute plus accepted fallbacks in priority order.
+// If AnyOf is empty only Name is checked.
+type AttributeCheck struct {
+	Name   string
+	RuleID string
+	AnyOf  []string
+}
+
+// AttributeResult is the outcome of one AttributeCheck.
+type AttributeResult struct {
+	RuleID       string `json:"rule_id"`
+	Attribute    string `json:"attribute"`
+	Status       string `json:"status"` // required: "pass"|"pass_via_fallback"|"fail"; optional: "present"|"present_via_fallback"|"absent"
+	FallbackUsed string `json:"fallback_used,omitempty"`
+}
+
+// SpanReport holds the full audit result for one SDK/instrumentation run.
+type SpanReport struct {
+	SDK             string            `json:"sdk"`
+	Instrumentation string            `json:"instrumentation"`
+	Profile         string            `json:"profile"`
+	Verdict         string            `json:"verdict"` // "PASS"|"PARTIAL"|"FAIL"
+	Required        []AttributeResult `json:"required"`
+	Optional        []AttributeResult `json:"optional"`
+	GeneratedAt     string            `json:"generated_at"`
+}
+
+// Profile pairs required and optional checks for a baseline profile.
+type Profile struct {
+	Name     string
+	Required []AttributeCheck
+	Optional []AttributeCheck
+}
+
+// ---------------------------------------------------------------------------
+// Baseline profile definitions — mirror sdk-comparison-baseline.json v1.2.1
+// ---------------------------------------------------------------------------
+
+var genericRequired = []AttributeCheck{
+	{Name: "gen_ai.provider.name", RuleID: "AR-001/AR-002",
+		AnyOf: []string{"gen_ai.provider.name", "gen_ai.system"}},
+	{Name: "service.name", RuleID: "AR-003"},
+	{Name: "gen_ai.request.model", RuleID: "AR-004"},
+	{Name: "gen_ai.response.model", RuleID: "AR-005"},
+	{Name: "gen_ai.usage.input_tokens", RuleID: "AR-006",
+		AnyOf: []string{"gen_ai.usage.input_tokens", "gen_ai.usage.prompt_tokens"}},
+	{Name: "gen_ai.usage.output_tokens", RuleID: "AR-007",
+		AnyOf: []string{"gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens"}},
+}
+
+var genericOptional = []AttributeCheck{
+	{Name: "gen_ai.operation.name", RuleID: "AR-008"},
+	{Name: "llm.request.type", RuleID: "AR-009"},
+	{Name: "gen_ai.agent.name", RuleID: "AR-010"},
+	{Name: "gen_ai.input.messages", RuleID: "AR-011",
+		AnyOf: []string{"gen_ai.input.messages", "gen_ai.prompt.0.content"}},
+	{Name: "gen_ai.output.messages", RuleID: "AR-012",
+		AnyOf: []string{"gen_ai.output.messages", "gen_ai.completion.0.content"}},
+	{Name: "gen_ai.token.type", RuleID: "AR-024"},
+	{Name: "gen_ai.conversation.id", RuleID: "AR-041"},
+	{Name: "gen_ai.request.temperature", RuleID: "AR-042"},
+	{Name: "gen_ai.system_instructions", RuleID: "AR-043"},
+	{Name: "gen_ai.client.token.usage", RuleID: "AR-044"},
+	{Name: "span.status_code", RuleID: "AR-047"},
+}
+
+// GenericProfile covers all provider-agnostic dashboard views.
+var GenericProfile = Profile{
+	Name:     "generic",
+	Required: genericRequired,
+	Optional: genericOptional,
+}
+
+// BedrockProfile extends generic with AWS Bedrock guardrail attributes.
+var BedrockProfile Profile
+
+func init() {
+	BedrockProfile = Profile{
+		Name: "bedrock",
+		Required: append(append([]AttributeCheck{}, genericRequired...),
+			AttributeCheck{Name: "gen_ai.bedrock.guardrail.activation", RuleID: "AR-017"},
+			AttributeCheck{Name: "gen_ai.bedrock.guardrail.content", RuleID: "AR-018"},
+			AttributeCheck{Name: "gen_ai.bedrock.guardrail.sensitive_info", RuleID: "AR-019"},
+		),
+		Optional: append(append([]AttributeCheck{}, genericOptional...),
+			AttributeCheck{Name: "gen_ai.bedrock.guardrail.topics", RuleID: "AR-020"},
+			AttributeCheck{Name: "gen_ai.bedrock.guardrail.words", RuleID: "AR-021"},
+			AttributeCheck{Name: "gen_ai.bedrock.guardrail.contextual", RuleID: "AR-040"},
+			AttributeCheck{Name: "gen_ai.prompt.caching", RuleID: "AR-045"},
+			AttributeCheck{Name: "gen_ai.guardrail.grounding_type", RuleID: "AR-046"},
+		),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Core functions
+// ---------------------------------------------------------------------------
+
+// evaluateCheck checks one attribute against a span record.
+// required controls whether the absent status is "fail" or "absent".
+func evaluateCheck(span map[string]interface{}, c AttributeCheck, required bool) AttributeResult {
+	res := AttributeResult{RuleID: c.RuleID, Attribute: c.Name}
+
+	candidates := c.AnyOf
+	if len(candidates) == 0 {
+		candidates = []string{c.Name}
+	}
+
+	for i, attr := range candidates {
+		v, ok := span[attr]
+		if !ok || v == nil || fmt.Sprint(v) == "" {
+			continue
+		}
+		if i == 0 {
+			if required {
+				res.Status = "pass"
+			} else {
+				res.Status = "present"
+			}
+		} else {
+			res.FallbackUsed = attr
+			if required {
+				res.Status = "pass_via_fallback"
+			} else {
+				res.Status = "present_via_fallback"
+			}
+		}
+		return res
+	}
+
+	if required {
+		res.Status = "fail"
+	} else {
+		res.Status = "absent"
+	}
+	return res
+}
+
+// buildReport evaluates all required and optional checks for a profile against
+// a single span record. Results are sorted by RuleID for determinism.
+func buildReport(sdk, instrumentation string, p Profile, span map[string]interface{}) SpanReport {
+	required := make([]AttributeResult, len(p.Required))
+	for i, c := range p.Required {
+		required[i] = evaluateCheck(span, c, true)
+	}
+	sort.Slice(required, func(i, j int) bool { return required[i].RuleID < required[j].RuleID })
+
+	optional := make([]AttributeResult, len(p.Optional))
+	for i, c := range p.Optional {
+		optional[i] = evaluateCheck(span, c, false)
+	}
+	sort.Slice(optional, func(i, j int) bool { return optional[i].RuleID < optional[j].RuleID })
+
+	verdict := "PASS"
+	for _, r := range required {
+		if r.Status == "fail" {
+			verdict = "FAIL"
+			break
+		}
+	}
+	if verdict == "PASS" {
+		for _, r := range optional {
+			if r.Status == "absent" {
+				verdict = "PARTIAL"
+				break
+			}
+		}
+	}
+
+	return SpanReport{
+		SDK:             sdk,
+		Instrumentation: instrumentation,
+		Profile:         p.Name,
+		Verdict:         verdict,
+		Required:        required,
+		Optional:        optional,
+		GeneratedAt:     time.Now().UTC().Format(time.RFC3339),
+	}
+}
+
+// writeReport writes both a JSON and a markdown report to test/e2e/reports/.
+func writeReport(t *testing.T, r SpanReport) {
+	t.Helper()
+	dir := filepath.Join(repoRoot(), "test", "e2e", "reports")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Logf("warning: create reports dir: %v", err)
+		return
+	}
+	base := filepath.Join(dir, r.SDK+"-"+r.Instrumentation)
+
+	jsonData, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		t.Logf("warning: marshal report: %v", err)
+		return
+	}
+	if err := os.WriteFile(base+".json", jsonData, 0o644); err != nil {
+		t.Logf("warning: write report json: %v", err)
+	}
+	if err := os.WriteFile(base+".md", []byte(buildMarkdown(r)), 0o644); err != nil {
+		t.Logf("warning: write report md: %v", err)
+	}
+}
+
+func buildMarkdown(r SpanReport) string {
+	verdictIcons := map[string]string{"PASS": "✅", "PARTIAL": "⚠️", "FAIL": "❌"}
+	icon := verdictIcons[r.Verdict]
+
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s / %s — Span Audit Report\n\n", r.SDK, r.Instrumentation)
+	fmt.Fprintf(&sb, "**Profile:** %s | **Verdict:** %s %s | **Generated:** %s\n\n",
+		r.Profile, icon, r.Verdict, r.GeneratedAt)
+
+	sb.WriteString("## Required Attributes\n\n")
+	sb.WriteString("| Rule ID | Attribute | Status | Notes |\n")
+	sb.WriteString("|---------|-----------|--------|-------|\n")
+	for _, a := range r.Required {
+		notes := ""
+		if a.FallbackUsed != "" {
+			notes = "via `" + a.FallbackUsed + "`"
+		}
+		fmt.Fprintf(&sb, "| %s | `%s` | %s %s | %s |\n",
+			a.RuleID, a.Attribute, statusIcon(a.Status), a.Status, notes)
+	}
+
+	sb.WriteString("\n## Optional Attributes\n\n")
+	sb.WriteString("| Rule ID | Attribute | Status |\n")
+	sb.WriteString("|---------|-----------|--------|\n")
+	for _, a := range r.Optional {
+		fmt.Fprintf(&sb, "| %s | `%s` | %s %s |\n",
+			a.RuleID, a.Attribute, statusIcon(a.Status), a.Status)
+	}
+
+	return sb.String()
+}
+
+func statusIcon(status string) string {
+	switch status {
+	case "pass", "pass_via_fallback", "present", "present_via_fallback":
+		return "✅"
+	case "fail":
+		return "❌"
+	case "absent":
+		return "⚪"
+	default:
+		return "❓"
+	}
+}
+
+// auditSpan polls DT until a span matching dql is found (3-minute timeout),
+// then fetches all spans in the same trace to build a complete attribute picture.
+// Writes JSON + markdown reports to test/e2e/reports/. Logs (but does NOT fail)
+// any required attribute gaps. The test fails only if no anchor span is found.
+func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)
+	if err != nil {
+		t.Fatalf("poll DT spans: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatalf("no spans returned from DT")
+	}
+
+	spans := fetchTraceSpans(t, ctx, records[0])
+	report := buildReport(sdk, instrumentation, p, mergeSpans(spans))
+	writeReport(t, report)
+
+	for _, r := range report.Required {
+		if r.Status == "fail" {
+			t.Logf("required attribute missing [%s] %s", r.RuleID, r.Attribute)
+		}
+	}
+	t.Logf("audit verdict: %s (%d spans in trace) — report written to reports/%s-%s.{json,md}",
+		report.Verdict, len(spans), sdk, instrumentation)
+}
+
+// fetchTraceSpans fetches all spans belonging to the same trace as anchor,
+// scoped to the same service.name. Falls back to [anchor] on any error.
+func fetchTraceSpans(t *testing.T, ctx context.Context, anchor map[string]interface{}) []map[string]interface{} {
+	t.Helper()
+
+	traceID, ok := anchor["trace.id"]
+	if !ok || traceID == nil {
+		t.Logf("trace.id absent in anchor span; using anchor only")
+		return []map[string]interface{}{anchor}
+	}
+	// Strip hyphens — DQL toUid() expects a 32-char hex string.
+	traceIDStr := strings.ReplaceAll(fmt.Sprint(traceID), "-", "")
+
+	svcName := fmt.Sprint(anchor["service.name"])
+	dql := fmt.Sprintf(
+		"fetch spans, from: now()-10m\n| filter service.name == %q\n| filter trace.id == toUid(%q)",
+		svcName, traceIDStr,
+	)
+
+	spans, err := dtClient.Execute(ctx, dql)
+	if err != nil {
+		t.Logf("warning: fetch trace spans: %v; using anchor only", err)
+		return []map[string]interface{}{anchor}
+	}
+	if len(spans) == 0 {
+		return []map[string]interface{}{anchor}
+	}
+	return spans
+}
+
+// mergeSpans folds multiple span records into one map: for each attribute, the
+// first non-empty value across all spans wins. This lets a single evaluateCheck
+// call see attributes spread across different spans of the same trace.
+func mergeSpans(spans []map[string]interface{}) map[string]interface{} {
+	merged := make(map[string]interface{})
+	for _, span := range spans {
+		for k, v := range span {
+			if _, exists := merged[k]; !exists && v != nil && fmt.Sprint(v) != "" {
+				merged[k] = v
+			}
+		}
+	}
+	return merged
+}

--- a/test/e2e/aws_bedrock_oneagent_test.go
+++ b/test/e2e/aws_bedrock_oneagent_test.go
@@ -8,9 +8,9 @@ func TestAWSBedrockOneAgent(t *testing.T) {
 	startApp(t, "aws-bedrock/oneagent")
 	triggerHaiku(t, true)
 
-	assertSpanExists(t,
+	auditSpan(t, "aws-bedrock", "oneagent", BedrockProfile,
 		`fetch spans, from: now()-10m
 | filter gen_ai.provider.name == "aws_bedrock" and dt.openpipeline.source == "oneagent"
-| limit 1`,
-	)
+| filter isNotNull(gen_ai.request.model)
+| limit 1`)
 }

--- a/test/e2e/aws_bedrock_openinference_test.go
+++ b/test/e2e/aws_bedrock_openinference_test.go
@@ -8,9 +8,9 @@ func TestAWSBedrockOpenInference(t *testing.T) {
 	startApp(t, "aws-bedrock/openinference")
 	triggerHaiku(t, true)
 
-	assertSpanExists(t,
+	auditSpan(t, "aws-bedrock", "openinference", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock/openinference"
-| limit 1`,
-	)
+| filter isNotNull(gen_ai.request.model)
+| limit 1`)
 }

--- a/test/e2e/aws_bedrock_opentelemetry_test.go
+++ b/test/e2e/aws_bedrock_opentelemetry_test.go
@@ -7,11 +7,12 @@ import (
 func TestAWSBedrockOpenTelemetry(t *testing.T) {
 	startCLIApp(t, "aws-bedrock/opentelemetry")
 
-	assertGenAISpan(t,
+	// gen_ai.response.model (AR-005) is not emitted by BedrockInstrumentor/BotocoreInstrumentor;
+	// tracked as a gap in test/e2e/sdk-analysis/aws-bedrock-opentelemetry.md.
+	auditSpan(t, "aws-bedrock", "opentelemetry", BedrockProfile,
 		`fetch spans, from: now()-10m
 | filter gen_ai.system == "aws.bedrock"
 | filter service.name == "aws-bedrock/opentelemetry"
-| limit 1`,
-		"aws.bedrock",
-	)
+| filter isNotNull(gen_ai.request.model)
+| limit 1`)
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -140,6 +140,43 @@ func assertSpanExists(t *testing.T, dql string) {
 	}
 }
 
+// assertSpanWithAttrs polls DT until a span matching dql is found (3-minute
+// timeout), then asserts that every attribute in required is non-null, and that
+// at least one attribute in each anyOf group is non-null.
+func assertSpanWithAttrs(t *testing.T, dql string, required []string, anyOf [][]string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)
+	if err != nil {
+		t.Fatalf("poll DT spans: %v", err)
+	}
+	if len(records) == 0 {
+		t.Fatal("no spans returned from DT")
+	}
+
+	span := records[0]
+	for _, attr := range required {
+		v, ok := span[attr]
+		if !ok || v == nil || v == "" {
+			t.Errorf("span missing required attribute %q", attr)
+		}
+	}
+	for _, group := range anyOf {
+		found := false
+		for _, attr := range group {
+			if v, ok := span[attr]; ok && v != nil && v != "" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("span missing at least one of %v", group)
+		}
+	}
+}
+
 // assertGenAISpan polls DT until a span matching dql is found (3-minute
 // timeout), then asserts gen_ai.system equals wantSystem.
 func assertGenAISpan(t *testing.T, dql, wantSystem string) {

--- a/test/e2e/internal/dynatrace/client.go
+++ b/test/e2e/internal/dynatrace/client.go
@@ -48,6 +48,11 @@ type queryError struct {
 	Message string `json:"message"`
 }
 
+// Execute runs dql once and returns whatever records DT returns (no retry).
+func (c *Client) Execute(ctx context.Context, dql string) ([]map[string]interface{}, error) {
+	return c.execute(ctx, dql)
+}
+
 // PollUntilSpans repeatedly executes the DQL query until at least one record is
 // returned or the context deadline is reached.
 func (c *Client) PollUntilSpans(ctx context.Context, dql string, interval time.Duration) ([]map[string]interface{}, error) {


### PR DESCRIPTION
## Summary

- **Report generation**: Replaces simple attribute assertions with a comprehensive audit system. Each test now runs `auditSpan`, which fetches all spans in the same trace (not just the anchor span), merges their attributes, and evaluates them against the baseline contract from `sdk-comparison-baseline.json`. Results are written as JSON + markdown reports per SDK/instrumentation. The test only fails if no span is found at all — missing required attributes surface as a `FAIL` verdict in the report without failing the Go test, so all SDKs produce reports even when instrumentation is incomplete.
- **CI integration**: Reports are uploaded as GitHub Actions artifacts (30-day retention) and written to the job summary for at-a-glance visibility without downloading.
- **`/update-audit-profiles` skill**: Claude Code slash command that instructs agents on how to keep the Go profile definitions in `audit_test.go` in sync with `sdk-comparison-baseline.json` when the baseline changes.
- **Bonus — local test README**: `test/e2e/README.md` documents prerequisites, environment setup, how to run individual tests, and troubleshooting steps.

Example report: https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples/actions/runs/27744551679

## Test plan

- [ ] Trigger workflow via `workflow_dispatch` and verify reports appear in job summary and artifacts
- [ ] Run a test locally and confirm `test/e2e/reports/*.{json,md}` are written and gitignored
- [ ] Verify `/update-audit-profiles` loads in Claude Code within this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)