### PR TITLE
feat: added ollama test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Cache Ollama model
         if: matrix.ollama_model != ''
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.ollama/models
           key: ollama-${{ matrix.ollama_model }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -32,6 +32,11 @@ jobs:
             app_dir: openai/oneagent
             test_run: TestOpenAIOneAgent
             otel_service_name: openai/oneagent
+          - name: ollama-oneagent
+            app_dir: ollama/oneagent
+            test_run: TestOllamaOneAgent
+            otel_service_name: ollama/oneagent
+            ollama_model: tinyllama
 
     steps:
       - name: Checkout
@@ -50,6 +55,15 @@ jobs:
 
       - name: Install uv
         run: pip install "uv==$UV_VERSION"
+
+      - name: Set up Ollama
+        if: matrix.ollama_model != ''
+        run: |
+          set -euo pipefail
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve &
+          timeout 30 bash -c 'until curl -sf http://localhost:11434/api/tags > /dev/null; do sleep 1; done'
+          ollama pull ${{ matrix.ollama_model }}
 
       - name: Install Dynatrace OneAgent
         env:
@@ -82,6 +96,7 @@ jobs:
           OPENAI_API_BASE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
           MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+          MODEL: ${{ matrix.ollama_model }}
         run: |
           set -euo pipefail
           if ! [[ "$TEST_RUN" =~ ^[A-Za-z][A-Za-z0-9_]+$ ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,8 +95,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           OPENAI_API_BASE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
-          MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
-          MODEL: ${{ matrix.ollama_model }}
+          MODEL: ${{ matrix.ollama_model != '' && matrix.ollama_model || secrets.AZURE_OPENAI_DEPLOYMENT }}
         run: |
           set -euo pipefail
           if ! [[ "$TEST_RUN" =~ ^[A-Za-z][A-Za-z0-9_]+$ ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,13 @@ jobs:
       - name: Install uv
         run: pip install "uv==$UV_VERSION"
 
+      - name: Cache Ollama model
+        if: matrix.ollama_model != ''
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.ollama/models
+          key: ollama-${{ matrix.ollama_model }}
+
       - name: Set up Ollama
         if: matrix.ollama_model != ''
         run: |

--- a/test/e2e/ollama_test.go
+++ b/test/e2e/ollama_test.go
@@ -1,0 +1,16 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestOllamaOneAgent(t *testing.T) {
+	startApp(t, "ollama/oneagent")
+	triggerHaiku(t, false)
+
+	auditSpan(t, "ollama", "oneagent", GenericProfile,
+		`fetch spans, from: now()-10m
+| filter gen_ai.provider.name == "ollama" and dt.openpipeline.source == "oneagent"
+| filter isNotNull(gen_ai.request.model)
+| limit 1`)
+}


### PR DESCRIPTION
# Description

Add TestOllamaOneAgent e2e test for the ollama/oneagent app. The workflow installs and starts Ollama directly on the GitHub runner, pulls tinyllama (cached across runs), and  points the app at the local instance. 

