### PR TITLE
feat: introduce pydantic test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -154,6 +154,10 @@ jobs:
             app_dir: openai/openinference
             test_run: TestOpenAIOpenInference
             otel_service_name: openai/openinference
+          - name: pydantic-ai-opentelemetry
+            app_dir: pydantic-ai/opentelemetry
+            test_run: TestPydanticAIOpenTelemetry
+            otel_service_name: pydantic-ai-music-agent
 
     steps:
       - name: Checkout
@@ -187,6 +191,10 @@ jobs:
           OPENAI_API_BASE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
           MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
           MAX_RUNS: '1'
         run: |
           set -euo pipefail

--- a/pydantic-ai/opentelemetry/Makefile
+++ b/pydantic-ai/opentelemetry/Makefile
@@ -14,7 +14,7 @@ install: ## Install Python dependencies
 	$(PYTHON) -m pip install -r backend/requirements.txt
 
 run: ## Run the Pydantic AI backend on port $(PORT)
-	$(PYTHON) -m uvicorn backend.main:app --host 0.0.0.0 --port $(PORT)
+	PYTHONPATH=backend $(PYTHON) -m uvicorn backend.main:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/pydantic-ai/opentelemetry/README.md
+++ b/pydantic-ai/opentelemetry/README.md
@@ -15,7 +15,7 @@ The app is a **Music History Explorer**: ask questions about jazz, classic rock,
 
 pydantic-ai ships with **native OpenTelemetry support** via `InstrumentationSettings`. Passing it to an `Agent` automatically emits spans following the [GenAI semantic conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/) — no monkey-patching or third-party SDKs required.
 
-`otel_setup.py` initialises a `TracerProvider` and `MeterProvider` that export to Dynatrace over OTLP/HTTP:
+`otel_setup.py` reads `DT_ENDPOINT` and `DT_API_TOKEN` from the environment and initialises a `TracerProvider` and `MeterProvider` that export to Dynatrace over OTLP/HTTP:
 
 ```python
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -91,17 +91,18 @@ Create or update the `.env` file at the **repo root** (one level above this fold
 
 ```bash
 # Dynatrace
-DT-ENDPOINT=https://<YOUR_ENV_ID>.live.dynatrace.com
-DT-TOKEN=dt0c01.<YOUR_TOKEN>
+DT_ENDPOINT=https://<YOUR_ENV_ID>.live.dynatrace.com
+DT_API_TOKEN=dt0c01.<YOUR_TOKEN>
 
 # AWS Bedrock
-Bedrock_username=<AWS_ACCESS_KEY_ID>
-bedrock_key=<AWS_SECRET_ACCESS_KEY>
+AWS_ACCESS_KEY_ID=<YOUR_AWS_ACCESS_KEY_ID>
+AWS_SECRET_ACCESS_KEY=<YOUR_AWS_SECRET_ACCESS_KEY>
 
-# Azure OpenAI (optional)
-Azure_openai_endpoint=https://<YOUR_RESOURCE>.openai.azure.com/
-Azure_openai_key=<YOUR_AZURE_KEY>
-Azure_openai_deployment=<YOUR_DEPLOYMENT_NAME>
+# Azure OpenAI (optional — falls back to Bedrock if not set)
+AZURE_OPENAI_ENDPOINT=https://<YOUR_RESOURCE>.openai.azure.com/
+AZURE_OPENAI_API_KEY=<YOUR_AZURE_KEY>
+AZURE_OPENAI_DEPLOYMENT=<YOUR_DEPLOYMENT_NAME>
+AZURE_OPENAI_API_VERSION=2024-02-01
 ```
 
 ### Install dependencies

--- a/pydantic-ai/opentelemetry/backend/main.py
+++ b/pydantic-ai/opentelemetry/backend/main.py
@@ -51,8 +51,8 @@ tracer = trace.get_tracer("music-agent-api")
 
 def _bedrock_provider() -> BedrockProvider:
     return BedrockProvider(
-        aws_access_key_id=os.environ["Bedrock_username"],
-        aws_secret_access_key=os.environ["bedrock_key"],
+        aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+        aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"],
         region_name="us-east-1",
     )
 
@@ -61,11 +61,11 @@ def build_azure_model() -> tuple[OpenAIModel, str, str]:
     # Azure endpoint is only reachable from the corporate network;
     # falls back to a Bedrock model when unavailable.
     provider = AzureProvider(
-        azure_endpoint=os.environ["Azure_openai_endpoint"],
-        api_key=os.environ["Azure_openai_key"],
-        api_version="2024-02-01",
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        api_version=os.environ["AZURE_OPENAI_API_VERSION"],
     )
-    deployment = os.environ["Azure_openai_deployment"]
+    deployment = os.environ["AZURE_OPENAI_DEPLOYMENT"]
     return OpenAIModel(deployment, provider=provider), "Azure OpenAI", deployment
 
 
@@ -103,6 +103,11 @@ class AnswerResponse(BaseModel):
     answer: str
     provider: str
     model: str
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
 
 
 @app.get("/")

--- a/pydantic-ai/opentelemetry/backend/otel_setup.py
+++ b/pydantic-ai/opentelemetry/backend/otel_setup.py
@@ -11,8 +11,8 @@ def setup_otel(service_name: str = "pydantic-ai-music-agent"):
     Returns (tracer_provider, meter_provider) so callers can pass them into
     pydantic-ai's InstrumentationSettings.
     """
-    dt_endpoint = os.environ.get("DT-ENDPOINT", "").rstrip("/")
-    dt_api_token = os.environ.get("DT-TOKEN", "")
+    dt_endpoint = os.environ.get("DT_ENDPOINT", "").rstrip("/")
+    dt_api_token = os.environ.get("DT_API_TOKEN", "")
 
     if not dt_endpoint or not dt_api_token:
         print("[otel] DT-ENDPOINT or DT-TOKEN not set — OTel export disabled")

--- a/test/e2e/audit_test.go
+++ b/test/e2e/audit_test.go
@@ -107,6 +107,34 @@ func init() {
 	}
 }
 
+// OpenAIProfile extends generic with OpenAI prompt-caching attributes.
+var OpenAIProfile Profile
+
+func init() {
+	OpenAIProfile = Profile{
+		Name:     "openai",
+		Required: append([]AttributeCheck{}, genericRequired...),
+		Optional: append(append([]AttributeCheck{}, genericOptional...),
+			AttributeCheck{Name: "gen_ai.prompt_caching", RuleID: "AR-022"},
+			AttributeCheck{Name: "gen_ai.cache.type", RuleID: "AR-023"},
+		),
+	}
+}
+
+// AzureProfile extends generic with Azure content filter attributes.
+var AzureProfile Profile
+
+func init() {
+	AzureProfile = Profile{
+		Name: "azure",
+		Required: append(append([]AttributeCheck{}, genericRequired...),
+			AttributeCheck{Name: "gen_ai.prompt.prompt_filter_results", RuleID: "AR-015"},
+			AttributeCheck{Name: "gen_ai.completion.content_filter_results", RuleID: "AR-016"},
+		),
+		Optional: append([]AttributeCheck{}, genericOptional...),
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Core functions
 // ---------------------------------------------------------------------------

--- a/test/e2e/audit_test.go
+++ b/test/e2e/audit_test.go
@@ -291,6 +291,33 @@ func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string)
 		report.Verdict, len(spans), sdk, instrumentation)
 }
 
+// auditSpanOptional is like auditSpan but skips the (sub)test when no anchor
+// span is found within the timeout instead of failing. Use for provider-specific
+// audits where the provider may not have been selected in the current run.
+func auditSpanOptional(t *testing.T, sdk, instrumentation string, p Profile, dql string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)
+	if err != nil || len(records) == 0 {
+		t.Skipf("no %s/%s spans found — provider likely not selected this run", sdk, instrumentation)
+		return
+	}
+
+	spans := fetchTraceSpans(t, ctx, records[0])
+	report := buildReport(sdk, instrumentation, p, mergeSpans(spans))
+	writeReport(t, report)
+
+	for _, r := range report.Required {
+		if r.Status == "fail" {
+			t.Logf("required attribute missing [%s] %s", r.RuleID, r.Attribute)
+		}
+	}
+	t.Logf("audit verdict: %s (%d spans in trace) — report written to reports/%s-%s.{json,md}",
+		report.Verdict, len(spans), sdk, instrumentation)
+}
+
 // fetchTraceSpans fetches all spans belonging to the same trace as anchor,
 // scoped to the same service.name. Polls until the span count stabilizes
 // (two consecutive equal non-zero counts) so spans that arrive in Dynatrace

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -59,6 +59,30 @@ func triggerHaiku(t *testing.T, withBody bool) {
 	}
 }
 
+// triggerMusicAgent POSTs a question to /api/ask on localhost:8000.
+func triggerMusicAgent(t *testing.T) {
+	t.Helper()
+	const url = "http://127.0.0.1:8000/api/ask"
+
+	b, _ := json.Marshal(map[string]string{"question": "Tell me the what is the shortest music known"})
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/ask: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /api/ask returned %d: %s", resp.StatusCode, b)
+	}
+}
+
 // startApp runs make install then starts make run in <repoRoot>/<appDir>.
 // Registers cleanup to stop the app and, for apps with a collector, make stop.
 func startApp(t *testing.T, appDir string) {

--- a/test/e2e/openai_oneagent_test.go
+++ b/test/e2e/openai_oneagent_test.go
@@ -8,7 +8,7 @@ func TestOpenAIOneAgent(t *testing.T) {
 	startApp(t, "openai/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "openai", "oneagent", GenericProfile,
+	auditSpan(t, "openai", "oneagent", OpenAIProfile,
 		`fetch spans, from: now()-10m
 | filter dt.openpipeline.source == "oneagent"
 | filter isNotNull(gen_ai.request.model)

--- a/test/e2e/openai_openinference_test.go
+++ b/test/e2e/openai_openinference_test.go
@@ -9,7 +9,7 @@ func TestOpenAIOpenInference(t *testing.T) {
 	// No triggerHaiku — the haiku request is issued by make run itself.
 	startCLIApp(t, "openai/openinference")
 
-	auditSpan(t, "openai", "openinference", GenericProfile,
+	auditSpan(t, "openai", "openinference", OpenAIProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "openai/openinference"
 | filter isNotNull(gen_ai.request.model)

--- a/test/e2e/pydantic_ai_opentelemetry_test.go
+++ b/test/e2e/pydantic_ai_opentelemetry_test.go
@@ -20,7 +20,7 @@ func TestPydanticAIOpenTelemetry(t *testing.T) {
 | limit 1`)
 	})
 	t.Run("azure", func(t *testing.T) {
-		auditSpanOptional(t, "pydantic-ai", "opentelemetry-azure", GenericProfile,
+		auditSpanOptional(t, "pydantic-ai", "opentelemetry-azure", AzureProfile,
 			`fetch spans, from: now()-10m
 | filter service.name == "pydantic-ai-music-agent"
 | filter gen_ai.provider.name == "Azure OpenAI"

--- a/test/e2e/pydantic_ai_opentelemetry_test.go
+++ b/test/e2e/pydantic_ai_opentelemetry_test.go
@@ -1,0 +1,19 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestPydanticAIOpenTelemetry(t *testing.T) {
+	startApp(t, "pydantic-ai/opentelemetry")
+	// Fire 3 requests so the random provider selection covers both Azure and Bedrock.
+	for range 3 {
+		triggerMusicAgent(t)
+	}
+
+	auditSpan(t, "pydantic-ai", "opentelemetry", GenericProfile,
+		`fetch spans, from: now()-10m
+| filter service.name == "pydantic-ai-music-agent"
+| filter isNotNull(gen_ai.provider.name)
+| limit 1`)
+}

--- a/test/e2e/pydantic_ai_opentelemetry_test.go
+++ b/test/e2e/pydantic_ai_opentelemetry_test.go
@@ -11,9 +11,20 @@ func TestPydanticAIOpenTelemetry(t *testing.T) {
 		triggerMusicAgent(t)
 	}
 
-	auditSpan(t, "pydantic-ai", "opentelemetry", GenericProfile,
-		`fetch spans, from: now()-10m
+	t.Run("bedrock", func(t *testing.T) {
+		auditSpanOptional(t, "pydantic-ai", "opentelemetry-bedrock", BedrockProfile,
+			`fetch spans, from: now()-10m
 | filter service.name == "pydantic-ai-music-agent"
-| filter isNotNull(gen_ai.provider.name)
+| filter gen_ai.provider.name == "AWS Bedrock"
+| filter isNotNull(gen_ai.request.model)
 | limit 1`)
+	})
+	t.Run("azure", func(t *testing.T) {
+		auditSpanOptional(t, "pydantic-ai", "opentelemetry-azure", GenericProfile,
+			`fetch spans, from: now()-10m
+| filter service.name == "pydantic-ai-music-agent"
+| filter gen_ai.provider.name == "Azure OpenAI"
+| filter isNotNull(gen_ai.request.model)
+| limit 1`)
+	})
 }


### PR DESCRIPTION
# Description

Add TestPydanticAIOpenTelemetry e2e test for the pydantic-ai/opentelemetry app. Fires 3 requests against the music agent to cover random provider selection (Azure OpenAI + AWS
  ▎ Bedrock). Adds triggerMusicAgent helper, wires Azure secrets into the otelcol job, fixes PYTHONPATH in the app Makefile so otel_setup resolves at runtime, and aligns all env 
  ▎ var names (DT_ENDPOINT, DT_API_TOKEN, AZURE_OPENAI_*, AWS_*) across app, otel setup, README, and CI.
  
  Adde Azure and OpenAI profiles

# Checklist

- [ x] I've added/updated screenshots from the Dynatrace platform showing the changes.
- [ x] I've added/updated the README with the changes.
