### PR TITLE
fix: pass RENOVATE_REPOSITORIES to renovate workflow

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,31 @@
   "timezone": "UTC",
   "schedule": ["before 5am on Monday"],
   "ignorePaths": ["**/.venv/**"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)Makefile$"],
+      "matchStrings": [
+        "ghcr\\.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:(?<currentValue>[^\\s]+)"
+      ],
+      "depNameTemplate": "ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["GO_VERSION: '(?<currentValue>[^']+)'"],
+      "depNameTemplate": "golang",
+      "datasourceTemplate": "golang-version"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["^\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["UV_VERSION: '(?<currentValue>[^']+)'"],
+      "depNameTemplate": "astral-sh/uv",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["pip_requirements", "pep621"],
@@ -20,6 +45,14 @@
     {
       "matchManagers": ["gomod"],
       "groupName": "go modules"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "groupName": "collector image"
+    },
+    {
+      "matchManagers": ["npm"],
+      "groupName": "npm dependencies"
     }
   ]
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 jobs:
   renovate:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -21,3 +21,5 @@ jobs:
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
## Summary

Fixes the Renovate workflow failing with `No repositories found`.

Without `RENOVATE_REPOSITORIES`, Renovate doesn't know which repo to operate on when running via `GITHUB_TOKEN`. Added the env var using `github.repository` so it always resolves to the correct repo without hardcoding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)