### PR TITLE
feat: introduce test/e2e/openai_agents_opentelemetry_test.go

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -154,6 +154,10 @@ jobs:
             app_dir: pydantic-ai/opentelemetry
             test_run: TestPydanticAIOpenTelemetry
             otel_service_name: pydantic-ai-music-agent
+          - name: openai-agents-opentelemetry
+            app_dir: openai-agents/opentelemetry
+            test_run: TestOpenAIAgentsOpenTelemetry
+            otel_service_name: openai-cs-agents
 
     steps:
       - name: Checkout

--- a/openai-agents/opentelemetry/README.md
+++ b/openai-agents/opentelemetry/README.md
@@ -13,82 +13,65 @@ This example contains a demo of a Customer Service Agent interface built on top 
 
 The Dynatrace full-stack observability platform combined with Traceloop's OpenLLMetry OpenTelemetry SDK can seamlessly provide comprehensive insights into Large Language Models (LLMs) in production environments. By observing AI models, businesses can make informed decisions, optimize performance, and ensure compliance with emerging AI regulations.
 
-Enabling and configuring OpenLLMetry is as easy as to copy/paste this snippet into your [`api.py`](./api.py) file.
+Enabling and configuring OpenLLMetry requires a Traceloop init call in [`api.py`](./api.py):
 
 ```python
 os.environ['TRACELOOP_TELEMETRY'] = "false"
 os.environ['OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE'] = "delta"
 
-def read_secret(secret: str):
-    try:
-        with open(f"/etc/secrets/{secret}", "r") as f:
-            return f.read().rstrip()
-    except Exception as e:
-        print("No token was provided")
-        print(e)
-        return ""
-
-token = read_secret("dynatrace_otel") # read your DT API token from a file in /etc/secrets/dynatrace_otel
+token = os.environ.get("DT_API_TOKEN") or read_secret("dynatrace_otel")
 headers = {"Authorization": f"Api-Token {token}"}
+_dt_base = os.environ.get("DT_ENDPOINT", "").rstrip("/")
+DT_OTLP_ENDPOINT = f"{_dt_base}/api/v2/otlp"
+
 from traceloop.sdk import Traceloop
 Traceloop.init(
     app_name="openai-cs-agents",
-    api_endpoint="https://wkf10640.live.dynatrace.com/api/v2/otlp", # configure your DT tenant here
+    api_endpoint=DT_OTLP_ENDPOINT,
     disable_batch=True,
     headers=headers,
     should_enrich_metrics=True,
 )
 ```
 
+The token is read from the `DT_API_TOKEN` environment variable first, falling back to `/etc/secrets/dynatrace_otel` for Kubernetes deployments.
 
 ## How to use
 
-### Setting your OpenAI API key
+### Prerequisites
 
-You can set your [Azure]OpenAI API key in your environment variables by running the following command in your terminal:
+- Python 3.11+
+- Azure OpenAI resource with a `gpt-4o` deployment
+- A Dynatrace environment with an API token scoped to `openTelemetryTrace.ingest` and `metrics.ingest`
 
-```bash
-export OPENAI_API_KEY=your_api_key
-```
-
-```bash
-export AZURE_OPENAI_API_KEY=your_api_key
-export AZURE_OPENAI_API_VERSION='2024-08-01-preview'
-export AZURE_OPENAI_ENDPOINT=your_endpoint
-export AZURE_OPENAI_DEPLOYMENT=your_deployment
-```
-
-
-Alternatively, you can set the `OPENAI` and/or `AZURE` environment variables in an `.env` file at the root of the `python-backend` folder. You will need to install the `python-dotenv` package to load the environment variables from the `.env` file.
-
-### Install dependencies
-
-Install the dependencies for the backend by running the following commands:
+### Configure environment variables
 
 ```bash
-cd python-backend
-python3.12 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+# Dynatrace
+export DT_ENDPOINT=https://<YOUR_ENV_ID>.live.dynatrace.com
+export DT_API_TOKEN=dt0c01.<YOUR_TOKEN>
+
+# Azure OpenAI
+export AZURE_OPENAI_API_KEY=<YOUR_KEY>
+export AZURE_OPENAI_API_VERSION=2024-08-01-preview
+export AZURE_OPENAI_ENDPOINT=https://<YOUR_RESOURCE>.openai.azure.com/
+export AZURE_OPENAI_DEPLOYMENT=gpt-4o
 ```
 
-For the UI, you can run:
+### Install and run
 
 ```bash
-cd ui
-npm install
+make install   # install Python dependencies
+make run       # start the backend on port 8000
+make request   # send a test question (in a second terminal)
 ```
 
-### Run the app
-
-From the `ui` folder, run:
+The backend API is available at [http://localhost:8000](http://localhost:8000). A Next.js frontend is available in the `ui/` folder:
 
 ```bash
-npm run dev
+cd ui && npm install && npm run dev
 ```
 
-The frontend will be available at: [http://localhost:3000](http://localhost:3000)
-
-This command will also start the backend.
+The frontend will be available at [http://localhost:3000](http://localhost:3000).
 
 ![Trace View](../../assets/trace-view.png)

--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -12,9 +12,10 @@ def read_secret(secret: str):
         print(e)
         return ""
 
-token = read_secret("dynatrace_otel")
+token = os.environ.get("DT_API_TOKEN") or read_secret("dynatrace_otel")
 headers = {"Authorization": f"Api-Token {token}"}
-DT_OTLP_ENDPOINT = "https://wkf10640.live.dynatrace.com/api/v2/otlp"
+_dt_base = os.environ.get("DT_ENDPOINT", "https://wkf10640.live.dynatrace.com").rstrip("/")
+DT_OTLP_ENDPOINT = f"{_dt_base}/api/v2/otlp"
 
 from traceloop.sdk import Traceloop
 Traceloop.init(
@@ -218,6 +219,11 @@ def _build_agents_list() -> List[Dict[str, Any]]:
 # =========================
 # Main Chat Endpoint
 # =========================
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(req: ChatRequest):

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -83,6 +83,30 @@ func triggerMusicAgent(t *testing.T) {
 	}
 }
 
+// triggerCSAgent POSTs an airline question to /chat on localhost:8000.
+func triggerCSAgent(t *testing.T) {
+	t.Helper()
+	const url = "http://127.0.0.1:8000/chat"
+
+	b, _ := json.Marshal(map[string]string{"message": "What is the baggage allowance for economy class?"})
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /chat: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /chat returned %d: %s", resp.StatusCode, b)
+	}
+}
+
 // startApp runs make install then starts make run in <repoRoot>/<appDir>.
 // Registers cleanup to stop the app and, for apps with a collector, make stop.
 func startApp(t *testing.T, appDir string) {

--- a/test/e2e/openai_agents_opentelemetry_test.go
+++ b/test/e2e/openai_agents_opentelemetry_test.go
@@ -1,0 +1,16 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
+	startApp(t, "openai-agents/opentelemetry")
+	triggerCSAgent(t)
+
+	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
+		`fetch spans, from: now()-10m
+| filter service.name == "openai-cs-agents"
+| filter gen_ai.system == "openai"
+| limit 1`)
+}

--- a/test/e2e/openai_agents_opentelemetry_test.go
+++ b/test/e2e/openai_agents_opentelemetry_test.go
@@ -11,6 +11,7 @@ func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
 	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "openai-cs-agents"
-| filter gen_ai.system == "openai"
+| filter gen_ai.provider.name == "azure.ai.openai"
+| filter isNotNull(gen_ai.request.model)
 | limit 1`)
 }

--- a/test/e2e/openai_oneagent_test.go
+++ b/test/e2e/openai_oneagent_test.go
@@ -13,6 +13,6 @@ func TestOpenAIOneAgent(t *testing.T) {
 | filter service.name == "openai/oneagent"
 | filter dt.openpipeline.source == "oneagent"
 | filter isNotNull(gen_ai.request.model)
-| sort timestamp desc
+| sort startTime desc
 | limit 1`)
 }

--- a/test/e2e/openai_oneagent_test.go
+++ b/test/e2e/openai_oneagent_test.go
@@ -13,6 +13,6 @@ func TestOpenAIOneAgent(t *testing.T) {
 | filter service.name == "openai/oneagent"
 | filter dt.openpipeline.source == "oneagent"
 | filter isNotNull(gen_ai.request.model)
-| sort startTime desc
+| sort timestamp desc
 | limit 1`)
 }


### PR DESCRIPTION
# Description

  - Add TestOpenAIAgentsOpenTelemetry: use gen_ai.provider.name == "azure.ai.openai" — Traceloop/OpenLLMetry emits the Azure-specific provider name
  - Update openai-agents/opentelemetry/README.md to document DT_ENDPOINT/DT_API_TOKEN env vars and correct Azure setup instructions

