### PR TITLE
feat: introduce maf e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -176,6 +176,10 @@ jobs:
             app_dir: litellm/opentelemetry
             test_run: TestLiteLLMOpenTelemetry
             otel_service_name: litellm-gateway
+          - name: microsoft-agent-framework-opentelemetry
+            app_dir: microsoft-agent-framework/opentelemetry
+            test_run: TestMicrosoftAgentFrameworkOpenTelemetry
+            otel_service_name: microsoft-agent-framework
 
     steps:
       - name: Checkout

--- a/microsoft-agent-framework/opentelemetry/README.md
+++ b/microsoft-agent-framework/opentelemetry/README.md
@@ -36,7 +36,7 @@ OPENAI_API_KEY=...
 OPENAI_API_BASE=https://<resource>.openai.azure.com/openai/deployments/<deployment>
 OPENAI_API_VERSION=2025-04-01-preview
 MODEL=<deployment>
-TEMPERATURE=0.7
+TEMPERATURE=1  # model-dependent: some models only accept the default (1)
 
 DT_ENDPOINT=https://<tenant>.live.dynatrace.com
 DT_API_TOKEN=dt0c01....

--- a/microsoft-agent-framework/opentelemetry/app.py
+++ b/microsoft-agent-framework/opentelemetry/app.py
@@ -57,6 +57,7 @@ async def main() -> None:
     openai_base = _require_env("OPENAI_API_BASE")
     openai_key = _require_env("OPENAI_API_KEY")
     api_version = os.getenv("OPENAI_API_VERSION", "2025-04-01-preview")
+    temperature = float(os.getenv("TEMPERATURE", "1"))
 
     client = OpenAIChatCompletionClient(
         model=model,
@@ -73,7 +74,7 @@ async def main() -> None:
         description="Writes concise haikus about software observability.",
         instructions="You write concise haikus about software observability.",
         default_options={
-            "temperature": 1,
+            "temperature": temperature,
             "conversation_id": str(uuid.uuid4()),
         },
     )

--- a/microsoft-agent-framework/opentelemetry/app.py
+++ b/microsoft-agent-framework/opentelemetry/app.py
@@ -73,6 +73,7 @@ async def main() -> None:
         description="Writes concise haikus about software observability.",
         instructions="You write concise haikus about software observability.",
         default_options={
+            "temperature": 1,
             "conversation_id": str(uuid.uuid4()),
         },
     )

--- a/microsoft-agent-framework/opentelemetry/app.py
+++ b/microsoft-agent-framework/opentelemetry/app.py
@@ -57,7 +57,6 @@ async def main() -> None:
     openai_base = _require_env("OPENAI_API_BASE")
     openai_key = _require_env("OPENAI_API_KEY")
     api_version = os.getenv("OPENAI_API_VERSION", "2025-04-01-preview")
-    temperature = float(os.getenv("TEMPERATURE", "0.7"))
 
     client = OpenAIChatCompletionClient(
         model=model,
@@ -74,7 +73,6 @@ async def main() -> None:
         description="Writes concise haikus about software observability.",
         instructions="You write concise haikus about software observability.",
         default_options={
-            "temperature": temperature,
             "conversation_id": str(uuid.uuid4()),
         },
     )

--- a/test/e2e/litellm_opentelemetry_test.go
+++ b/test/e2e/litellm_opentelemetry_test.go
@@ -11,6 +11,6 @@ func TestLiteLLMOpenTelemetry(t *testing.T) {
 	auditSpan(t, "litellm", "opentelemetry", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "litellm-gateway"
-| filter isNotNull(gen_ai.system)
+| filter isNotNull(gen_ai.provider.name)
 | limit 1`)
 }

--- a/test/e2e/microsoft_agent_framework_opentelemetry_test.go
+++ b/test/e2e/microsoft_agent_framework_opentelemetry_test.go
@@ -10,6 +10,8 @@ func TestMicrosoftAgentFrameworkOpenTelemetry(t *testing.T) {
 	auditSpan(t, "microsoft-agent-framework", "opentelemetry", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "microsoft-agent-framework"
-| filter isNotNull(gen_ai.system)
+| filter gen_ai.provider.name == "microsoft.agent_framework"
+| filter isNotNull(gen_ai.request.model)
+| sort timestamp desc
 | limit 1`)
 }

--- a/test/e2e/microsoft_agent_framework_opentelemetry_test.go
+++ b/test/e2e/microsoft_agent_framework_opentelemetry_test.go
@@ -1,0 +1,15 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestMicrosoftAgentFrameworkOpenTelemetry(t *testing.T) {
+	startCLIApp(t, "microsoft-agent-framework/opentelemetry")
+
+	auditSpan(t, "microsoft-agent-framework", "opentelemetry", GenericProfile,
+		`fetch spans, from: now()-10m
+| filter service.name == "microsoft-agent-framework"
+| filter isNotNull(gen_ai.system)
+| limit 1`)
+}


### PR DESCRIPTION
# Description

Adds a nightly e2e test for the Microsoft Agent Framework OpenTelemetry example.

  - test/e2e/microsoft_agent_framework_opentelemetry_test.go — new test: runs the app as a CLI process (startCLIApp), polls Dynatrace for a span with service.name == 
  "microsoft-agent-framework" and a non-null gen_ai.system, then audits it against GenericProfile.
  - .github/workflows/e2e.yml — adds a microsoft-agent-framework-opentelemetry matrix entry to the otelcol job; existing Azure OpenAI credentials (OPENAI_API_KEY,
  OPENAI_API_BASE, OPENAI_API_VERSION, MODEL) are already present in that job.
  - microsoft-agent-framework/opentelemetry/app.py — fixes a 400 error: the deployed model only accepts temperature=1; the framework's internal default is 0.7, so we now
  explicitly pass temperature=1 in default_options to override it.

