### PR TITLE
feat: intorduce e2e test for groq mocked with ollama

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
             app_dir: groq/oneagent
             test_run: TestGroqOneAgent
             otel_service_name: groq/oneagent
-            groq_model: llama-3.1-8b-instant
+            ollama_model: tinyllama
 
     steps:
       - name: Checkout
@@ -106,7 +106,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           OPENAI_API_BASE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
-          MODEL: ${{ matrix.ollama_model != '' && matrix.ollama_model || matrix.groq_model != '' && matrix.groq_model || secrets.AZURE_OPENAI_DEPLOYMENT }}
+          MODEL: ${{ matrix.ollama_model != '' && matrix.ollama_model || secrets.AZURE_OPENAI_DEPLOYMENT }}
         run: |
           set -euo pipefail
           if ! [[ "$TEST_RUN" =~ ^[A-Za-z][A-Za-z0-9_]+$ ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,7 @@ jobs:
             app_dir: groq/oneagent
             test_run: TestGroqOneAgent
             otel_service_name: groq/oneagent
+            groq_model: llama-3.1-8b-instant
 
     steps:
       - name: Checkout
@@ -105,7 +106,7 @@ jobs:
           OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
           OPENAI_API_BASE: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
           OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
-          MODEL: ${{ matrix.ollama_model != '' && matrix.ollama_model || secrets.AZURE_OPENAI_DEPLOYMENT }}
+          MODEL: ${{ matrix.ollama_model != '' && matrix.ollama_model || matrix.groq_model != '' && matrix.groq_model || secrets.AZURE_OPENAI_DEPLOYMENT }}
         run: |
           set -euo pipefail
           if ! [[ "$TEST_RUN" =~ ^[A-Za-z][A-Za-z0-9_]+$ ]]; then

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,6 +33,14 @@ jobs:
             test_run: TestOllamaOneAgent
             otel_service_name: ollama/oneagent
             ollama_model: tinyllama
+          # MOCKED: no real GROQ_API_KEY yet — Groq SDK is pointed at a local
+          # Ollama instance (tinyllama) via GROQ_BASE_URL. Replace ollama_model
+          # with a real GROQ_API_KEY secret once ICP-6025 is complete.
+          - name: groq-oneagent
+            app_dir: groq/oneagent
+            test_run: TestGroqOneAgent
+            otel_service_name: groq/oneagent
+            ollama_model: tinyllama
 
     steps:
       - name: Checkout

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,14 +33,13 @@ jobs:
             test_run: TestOllamaOneAgent
             otel_service_name: ollama/oneagent
             ollama_model: tinyllama
-          # MOCKED: no real GROQ_API_KEY yet — Groq SDK is pointed at a local
-          # Ollama instance (tinyllama) via GROQ_BASE_URL. Replace ollama_model
-          # with a real GROQ_API_KEY secret once ICP-6025 is complete.
+          # MOCKED: no real GROQ_API_KEY yet — an in-process httptest stub intercepts
+          # Groq SDK calls. OneAgent instruments at the SDK level so spans carry
+          # real Groq attributes. Replace with GROQ_API_KEY secret once ICP-6025 is complete.
           - name: groq-oneagent
             app_dir: groq/oneagent
             test_run: TestGroqOneAgent
             otel_service_name: groq/oneagent
-            ollama_model: tinyllama
 
     steps:
       - name: Checkout

--- a/groq/oneagent/app.py
+++ b/groq/oneagent/app.py
@@ -16,10 +16,7 @@ def health():
 
 @app.post("/haiku", response_class=PlainTextResponse)
 async def haiku() -> str:
-    client = Groq(
-        api_key=os.getenv("GROQ_API_KEY"),
-        base_url=os.getenv("GROQ_BASE_URL"),
-    )
+    client = Groq(api_key=os.getenv("GROQ_API_KEY"))
 
     def _call() -> str:
         response = client.chat.completions.create(

--- a/groq/oneagent/app.py
+++ b/groq/oneagent/app.py
@@ -16,7 +16,10 @@ def health():
 
 @app.post("/haiku", response_class=PlainTextResponse)
 async def haiku() -> str:
-    client = Groq(api_key=os.getenv("GROQ_API_KEY"))
+    client = Groq(
+        api_key=os.getenv("GROQ_API_KEY"),
+        base_url=os.getenv("GROQ_BASE_URL"),
+    )
 
     def _call() -> str:
         response = client.chat.completions.create(

--- a/test/e2e/groq_test.go
+++ b/test/e2e/groq_test.go
@@ -9,11 +9,10 @@ func TestGroqOneAgent(t *testing.T) {
 	startApp(t, "groq/oneagent")
 	triggerHaiku(t, false)
 
-	// TODO: confirm gen_ai.system / gen_ai.provider.name emitted by OneAgent
-	// for the Groq SDK and tighten the provider filter once span metadata is known.
 	auditSpan(t, "groq", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "groq/oneagent"
+| filter gen_ai.provider.name == "groq"
 | filter dt.openpipeline.source == "oneagent"
 | filter isNotNull(gen_ai.request.model)
 | sort timestamp desc

--- a/test/e2e/groq_test.go
+++ b/test/e2e/groq_test.go
@@ -1,0 +1,30 @@
+package e2e
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGroqOneAgent(t *testing.T) {
+	if os.Getenv("GROQ_API_KEY") == "" {
+		// No real key — point the Groq SDK at a local Ollama instance.
+		// Ollama serves an OpenAI-compatible API at /v1, which aligns with
+		// the Groq SDK's base-URL override (GROQ_BASE_URL replaces the full
+		// https://api.groq.com/openai/v1 default).
+		// In CI the ollama_model matrix field triggers install + model pull.
+		t.Setenv("GROQ_API_KEY", "ollama-stub")
+		t.Setenv("GROQ_BASE_URL", "http://localhost:11434/v1")
+	}
+	startApp(t, "groq/oneagent")
+	triggerHaiku(t, false)
+
+	// TODO: confirm gen_ai.system / gen_ai.provider.name emitted by OneAgent
+	// for the Groq SDK and tighten the provider filter once span metadata is known.
+	auditSpan(t, "groq", "oneagent", GenericProfile,
+		`fetch spans, from: now()-10m
+| filter service.name == "groq/oneagent"
+| filter dt.openpipeline.source == "oneagent"
+| filter isNotNull(gen_ai.request.model)
+| sort timestamp desc
+| limit 1`)
+}

--- a/test/e2e/groq_test.go
+++ b/test/e2e/groq_test.go
@@ -1,20 +1,11 @@
 package e2e
 
 import (
-	"os"
 	"testing"
 )
 
 func TestGroqOneAgent(t *testing.T) {
-	if os.Getenv("GROQ_API_KEY") == "" {
-		// No real key — point the Groq SDK at a local Ollama instance.
-		// The SDK default base is https://api.groq.com (host only); it appends
-		// /openai/v1/chat/completions internally, so GROQ_BASE_URL must be the
-		// bare host so the final path aligns with Ollama's OpenAI-compatible endpoint.
-		// In CI the ollama_model matrix field triggers install + model pull.
-		t.Setenv("GROQ_API_KEY", "ollama-stub")
-		t.Setenv("GROQ_BASE_URL", "http://localhost:11434")
-	}
+	startOpenAICompatibleMock(t, "GROQ_API_KEY", "GROQ_BASE_URL")
 	startApp(t, "groq/oneagent")
 	triggerHaiku(t, false)
 

--- a/test/e2e/groq_test.go
+++ b/test/e2e/groq_test.go
@@ -8,12 +8,12 @@ import (
 func TestGroqOneAgent(t *testing.T) {
 	if os.Getenv("GROQ_API_KEY") == "" {
 		// No real key — point the Groq SDK at a local Ollama instance.
-		// Ollama serves an OpenAI-compatible API at /v1, which aligns with
-		// the Groq SDK's base-URL override (GROQ_BASE_URL replaces the full
-		// https://api.groq.com/openai/v1 default).
+		// The SDK default base is https://api.groq.com (host only); it appends
+		// /openai/v1/chat/completions internally, so GROQ_BASE_URL must be the
+		// bare host so the final path aligns with Ollama's OpenAI-compatible endpoint.
 		// In CI the ollama_model matrix field triggers install + model pull.
 		t.Setenv("GROQ_API_KEY", "ollama-stub")
-		t.Setenv("GROQ_BASE_URL", "http://localhost:11434/v1")
+		t.Setenv("GROQ_BASE_URL", "http://localhost:11434")
 	}
 	startApp(t, "groq/oneagent")
 	triggerHaiku(t, false)

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -283,6 +284,52 @@ func assertSpanWithAttrs(t *testing.T, dql string, required []string, anyOf [][]
 			t.Errorf("span missing at least one of %v", group)
 		}
 	}
+}
+
+// startOpenAICompatibleMock starts a local OpenAI-compatible stub and wires it
+// into the test environment via the given env var names. Only active when
+// apiKeyEnvVar is not already set — real-key CI runs pass through unmodified.
+// Serves both /openai/v1/chat/completions and /v1/chat/completions so it works
+// with SDKs that include the version prefix in their base URL (e.g. Groq) and
+// those that do not (e.g. OpenAI-compatible clients pointing at a bare host).
+// model is returned in the response body; set it to the value of MODEL or any
+// sentinel string useful for asserting gen_ai.response.model in DT.
+func startOpenAICompatibleMock(t *testing.T, apiKeyEnvVar, baseURLEnvVar string) {
+	t.Helper()
+	if os.Getenv(apiKeyEnvVar) != "" {
+		return
+	}
+	handler := func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"id":      "chatcmpl-mock",
+			"object":  "chat.completion",
+			"created": 1700000000,
+			"model":   os.Getenv("MODEL"),
+			"choices": []map[string]interface{}{
+				{
+					"index": 0,
+					"message": map[string]string{
+						"role":    "assistant",
+						"content": "Code flows like water\nBugs surface in morning light\nLogs reveal the truth",
+					},
+					"finish_reason": "stop",
+				},
+			},
+			"usage": map[string]int{
+				"prompt_tokens":     10,
+				"completion_tokens": 20,
+				"total_tokens":      30,
+			},
+		})
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/openai/v1/chat/completions", handler)
+	mux.HandleFunc("/v1/chat/completions", handler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	t.Setenv(baseURLEnvVar, srv.URL)
+	t.Setenv(apiKeyEnvVar, "mock-key-for-e2e")
 }
 
 // assertGenAISpan polls DT until a span matching dql is found (3-minute


### PR DESCRIPTION
# Description

Adds a nightly e2e test for the Groq OneAgent example using an in-process OpenAI-compatible mock so the test runs without a real GROQ_API_KEY.

  - test/e2e/groq_test.go — new test: starts the app, POSTs /haiku, polls DT for a span with gen_ai.provider.name == "groq" (confirmed from a real CI run), audits against
  GenericProfile.
  - test/e2e/helpers_test.go — adds startOpenAICompatibleMock, a reusable helper that stubs any OpenAI-compatible SDK (serves both /openai/v1/ and /v1/ path conventions)
  when the given API key env var is absent. No-op when a real key is present, so switching to GROQ_API_KEY secret (ICP-6025) requires no test changes.
  - .github/workflows/e2e.yml — adds groq-oneagent matrix entry to the oneagent job with groq_model: llama-3.1-8b-instant to avoid the Azure deployment name bleeding in as
  MODEL.