### PR TITLE
chore: Migrate all Python examples to uv

### DIFF
--- a/aws-bedrock/opentelemetry/Makefile
+++ b/aws-bedrock/opentelemetry/Makefile
@@ -3,7 +3,6 @@ SHELL            := /bin/bash
 export
 
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 DT_ENDPOINT      ?= https://your-tenant.live.dynatrace.com
 DT_API_TOKEN     ?= dt0c01.*****
@@ -17,11 +16,11 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Start collector + run the AWS Bedrock tracing demo
 	@$(MAKE) _collector CONFIG=otel-collector-config.yaml
-	$(PYTHON) main.py
+	uv run python3 main.py
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/aws-bedrock/opentelemetry/README.md
+++ b/aws-bedrock/opentelemetry/README.md
@@ -31,6 +31,7 @@ All spans are grouped into logical `@workflow` / `@task` / `@agent` spans via Tr
 ### Prerequisites
 
 - Python 3.9+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - AWS credentials configured (`aws configure` or environment variables) with Bedrock access in `us-east-1`
 - A running [OpenTelemetry Collector](#opentelemetry-collector) forwarding to Dynatrace
 - A Dynatrace environment with an API token that has the **`openTelemetryTrace.ingest`** and **`logs.ingest`** scopes
@@ -38,9 +39,7 @@ All spans are grouped into logical `@workflow` / `@task` / `@agent` spans via Tr
 ### Install dependencies
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+make install
 ```
 
 ### Configure the OTel Collector
@@ -85,8 +84,7 @@ docker run \
 ### Run
 
 ```bash
-source .venv/bin/activate
-python3 main.py
+make run
 ```
 
 The script runs continuously, calling both the Converse and Invoke APIs every 5 seconds. Stop it with `Ctrl+C`.

--- a/aws-bedrock/opentelemetry/pyproject.toml
+++ b/aws-bedrock/opentelemetry/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "aws-bedrock-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "boto3>=1.43.0",
+    "traceloop-sdk>=0.61.0",
+    "opentelemetry-instrumentation-bedrock>=0.61.0",
+    "opentelemetry-instrumentation-botocore>=0.61.0",
+    "opentelemetry-instrumentation-requests>=0.61.0",
+    "opentelemetry-instrumentation-asyncio>=0.61.0",
+    "requests>=2.32.0",
+    "tenacity>=9.0.0",
+]

--- a/aws-bedrock/opentelemetry/pyproject.toml
+++ b/aws-bedrock/opentelemetry/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "opentelemetry-instrumentation-asyncio>=0.61.0",
     "requests>=2.32.0",
     "tenacity>=9.0.0",
+    "httpx>=0.27.0",
 ]

--- a/cohere/oneagent/Makefile
+++ b/cohere/oneagent/Makefile
@@ -5,7 +5,6 @@ export
 APP_IMAGE        ?=
 BUILD_PLATFORM   ?= linux/amd64
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -13,10 +12,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
 	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .

--- a/cohere/oneagent/README.md
+++ b/cohere/oneagent/README.md
@@ -5,6 +5,7 @@ Demonstrates tracing Cohere SDK API calls with Dynatrace via OneAgent auto-instr
 ## Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Cohere API key (`COHERE_API_KEY`)
 - Dynatrace OneAgent installed on the host
 

--- a/cohere/oneagent/pyproject.toml
+++ b/cohere/oneagent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "cohere-oneagent-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "cohere>=5.0.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+]

--- a/groq/oneagent/Makefile
+++ b/groq/oneagent/Makefile
@@ -5,7 +5,6 @@ export
 APP_IMAGE        ?=
 BUILD_PLATFORM   ?= linux/amd64
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -13,10 +12,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
 	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .

--- a/groq/oneagent/README.md
+++ b/groq/oneagent/README.md
@@ -5,6 +5,7 @@ Demonstrates tracing Groq SDK API calls with Dynatrace via OneAgent auto-instrum
 ## Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Groq API key (`GROQ_API_KEY`)
 - Dynatrace OneAgent installed on the host
 

--- a/groq/oneagent/pyproject.toml
+++ b/groq/oneagent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "groq-oneagent-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "groq>=0.9.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+]

--- a/haystack/oneagent/Makefile
+++ b/haystack/oneagent/Makefile
@@ -5,7 +5,6 @@ export
 APP_IMAGE        ?=
 BUILD_PLATFORM   ?= linux/amd64
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -13,10 +12,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
 	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .

--- a/haystack/oneagent/README.md
+++ b/haystack/oneagent/README.md
@@ -5,6 +5,7 @@ Demonstrates tracing Haystack framework (Azure OpenAI backend) API calls with Dy
 ## Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Azure OpenAI resource (`AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_DEPLOYMENT`)
 - Dynatrace OneAgent installed on the host
 

--- a/haystack/oneagent/pyproject.toml
+++ b/haystack/oneagent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "haystack-oneagent-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "haystack-ai>=2.0.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+]

--- a/langfuse/opentelemetry/Makefile
+++ b/langfuse/opentelemetry/Makefile
@@ -12,8 +12,6 @@ DT_API_TOKEN        ?= dt0c01.*****
 APP_IMAGE           ?=
 BUILD_PLATFORM      ?= linux/amd64
 
-PYTHON              := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
-
 override COLLECTOR_IMAGE     := ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:0.50.0
 override COLLECTOR_CONTAINER := otel-collector
 
@@ -23,7 +21,7 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 # ---------------------------------------------------------------------------
 # run: collector applies langfuse.* -> gen_ai.* transforms locally
@@ -39,7 +37,7 @@ run: ## Start collector (transform mode) + app  [no OpenPipeline needed]
 	@OTEL_SERVICE_NAME=langfuse \
 	  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 	  OTEL_EXPORTER_OTLP_HEADERS="" \
-	  $(PYTHON) app.py
+	  uv run python3 app.py
 
 # ---------------------------------------------------------------------------
 # run-openpipeline: app sends directly to Dynatrace — OpenPipeline transforms
@@ -50,7 +48,7 @@ run-openpipeline: ## Run app directly to Dynatrace  [requires OpenPipeline in Dy
 	@OTEL_SERVICE_NAME=langfuse-openpipeline \
 	  OTEL_EXPORTER_OTLP_ENDPOINT=$(DT_ENDPOINT)/api/v2/otlp \
 	  OTEL_EXPORTER_OTLP_HEADERS="Authorization=Api-Token $(DT_API_TOKEN)" \
-	  $(PYTHON) app.py
+	  uv run python3 app.py
 
 # ---------------------------------------------------------------------------
 # Internal targets
@@ -92,7 +90,7 @@ request: ## Run a haiku request through the running collector
 	@OTEL_SERVICE_NAME=langfuse \
 	  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 	  OTEL_EXPORTER_OTLP_HEADERS="" \
-	  $(PYTHON) app.py
+	  uv run python3 app.py
 
 # ---------------------------------------------------------------------------
 # Utility

--- a/langfuse/opentelemetry/README.md
+++ b/langfuse/opentelemetry/README.md
@@ -33,6 +33,7 @@ Langfuse uses its own semantic conventions (`langfuse.observation.type`, `langfu
 - A Dynatrace tenant -- start a free trial at https://dt-url.net/trial
 - Docker installed and running (Option A only)
 - Python 3.8+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - An OpenAI-compatible API key and endpoint
 
 ---

--- a/langfuse/opentelemetry/pyproject.toml
+++ b/langfuse/opentelemetry/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "langfuse-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "langfuse>=3.0.0",
+    "openai>=1.0.0",
+    "opentelemetry-sdk>=1.25.0",
+    "opentelemetry-exporter-otlp>=1.25.0",
+]

--- a/litellm/opentelemetry/Makefile
+++ b/litellm/opentelemetry/Makefile
@@ -3,7 +3,6 @@ SHELL            := /bin/bash
 export
 
 PORT                 ?= 8000
-PYTHON               := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 COLLECTOR_BASE_URL   ?= localhost:4317
 
 DT_ENDPOINT          ?= https://your-tenant.live.dynatrace.com
@@ -18,11 +17,11 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies (fastapi-instrumentation demo)
-	$(PYTHON) -m pip install -r fastapi-instrumentation/requirements.txt
+	uv sync
 
 run: ## Start collector + FastAPI instrumentation demo on port $(PORT)
 	@$(MAKE) _collector CONFIG=otel-collector-config.yaml
-	cd fastapi-instrumentation && COLLECTOR_BASE_URL=$(COLLECTOR_BASE_URL) $(PYTHON) -m uvicorn main:app --host 0.0.0.0 --port $(PORT)
+	cd fastapi-instrumentation && COLLECTOR_BASE_URL=$(COLLECTOR_BASE_URL) uv run python3 -m uvicorn main:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/litellm/opentelemetry/fastapi-instrumentation/README.md
+++ b/litellm/opentelemetry/fastapi-instrumentation/README.md
@@ -20,6 +20,7 @@ All signals are forwarded via gRPC to a local OTel Collector at `localhost:4317`
 ### Prerequisites
 
 - Python 3.9+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - A running [OpenTelemetry Collector](../README.md) forwarding to Dynatrace
 - At least one LLM provider API key (xAI, Groq, or Anthropic)
 - A Dynatrace environment with an API token that has the **`openTelemetryTrace.ingest`**, **`metrics.ingest`**, and **`logs.ingest`** scopes
@@ -78,10 +79,9 @@ docker run \
 ### Run
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-uvicorn main:app --reload --port 8000
+cd litellm/opentelemetry
+make install
+make run
 ```
 
 ### Call the API

--- a/litellm/opentelemetry/litellm-gateway-with-instrumentation/README.md
+++ b/litellm/opentelemetry/litellm-gateway-with-instrumentation/README.md
@@ -27,6 +27,7 @@ All signals are forwarded via gRPC to a local OTel Collector at `localhost:4317`
 ### Prerequisites
 
 - Python 3.9+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - [Ollama](https://ollama.com) running locally (`ollama serve`) with `llama3.2` and `all-minilm` pulled
 - A running [OpenTelemetry Collector](../README.md) forwarding to Dynatrace
 - A Dynatrace environment with an API token that has the **`openTelemetryTrace.ingest`** and **`metrics.ingest`** scopes
@@ -84,10 +85,9 @@ docker run \
 ### Run
 
 ```bash
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
-python3 basic.py
+cd litellm/opentelemetry/litellm-gateway-with-instrumentation
+uv sync
+uv run python3 basic.py
 ```
 
 The proxy starts on `http://localhost:4000`. The Admin UI is available at `http://localhost:4000/ui`.

--- a/litellm/opentelemetry/litellm-gateway-with-instrumentation/pyproject.toml
+++ b/litellm/opentelemetry/litellm-gateway-with-instrumentation/pyproject.toml
@@ -3,11 +3,10 @@ name = "litellm-gateway-demo"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "litellm>=1.89.0",
+    "litellm[proxy]>=1.89.0",
     "traceloop-sdk>=0.61.0",
     "opentelemetry-sdk>=1.42.0",
     "opentelemetry-exporter-otlp-proto-grpc>=1.42.0",
     "opentelemetry-instrumentation-fastapi>=0.61.0",
     "opentelemetry-instrumentation-httpx>=0.61.0",
-    "websockets>=12.0",
 ]

--- a/litellm/opentelemetry/litellm-gateway-with-instrumentation/pyproject.toml
+++ b/litellm/opentelemetry/litellm-gateway-with-instrumentation/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-grpc>=1.42.0",
     "opentelemetry-instrumentation-fastapi>=0.61.0",
     "opentelemetry-instrumentation-httpx>=0.61.0",
+    "websockets>=12.0",
 ]

--- a/litellm/opentelemetry/litellm-gateway-with-instrumentation/pyproject.toml
+++ b/litellm/opentelemetry/litellm-gateway-with-instrumentation/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "litellm-gateway-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "litellm>=1.89.0",
+    "traceloop-sdk>=0.61.0",
+    "opentelemetry-sdk>=1.42.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.42.0",
+    "opentelemetry-instrumentation-fastapi>=0.61.0",
+    "opentelemetry-instrumentation-httpx>=0.61.0",
+]

--- a/litellm/opentelemetry/pyproject.toml
+++ b/litellm/opentelemetry/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "litellm-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "litellm>=1.89.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "traceloop-sdk>=0.61.0",
+    "opentelemetry-sdk>=1.42.0",
+    "opentelemetry-exporter-otlp-proto-grpc>=1.42.0",
+    "opentelemetry-instrumentation-fastapi>=0.61.0",
+    "opentelemetry-instrumentation-httpx>=0.61.0",
+    "pydantic>=2.0.0",
+]

--- a/litellm/opentelemetry/pyproject.toml
+++ b/litellm/opentelemetry/pyproject.toml
@@ -12,4 +12,5 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.61.0",
     "opentelemetry-instrumentation-httpx>=0.61.0",
     "pydantic>=2.0.0",
+    "websockets>=12.0",
 ]

--- a/litellm/opentelemetry/pyproject.toml
+++ b/litellm/opentelemetry/pyproject.toml
@@ -3,7 +3,7 @@ name = "litellm-opentelemetry-demo"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "litellm>=1.89.0",
+    "litellm[proxy]>=1.89.0",
     "fastapi>=0.115.0",
     "uvicorn>=0.30.0",
     "traceloop-sdk>=0.61.0",
@@ -12,5 +12,4 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.61.0",
     "opentelemetry-instrumentation-httpx>=0.61.0",
     "pydantic>=2.0.0",
-    "websockets>=12.0",
 ]

--- a/microsoft-agent-framework/opentelemetry/Makefile
+++ b/microsoft-agent-framework/opentelemetry/Makefile
@@ -1,12 +1,16 @@
-PYTHON ?= python3
-VENV ?= .venv
+SHELL            := /bin/bash
+-include .env
+export
 
-.PHONY: install run
+PORT             ?= 8000
 
-install:
-	$(PYTHON) -m venv $(VENV)
-	. $(VENV)/bin/activate && pip install -r requirements.txt
+.PHONY: install run help
 
-run:
-	@if [ -f .env ]; then set -a; . ./.env; set +a; fi; \
-	. $(VENV)/bin/activate && python app.py
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install Python dependencies
+	uv sync
+
+run: ## Run the agent app
+	uv run python3 app.py

--- a/microsoft-agent-framework/opentelemetry/README.md
+++ b/microsoft-agent-framework/opentelemetry/README.md
@@ -22,6 +22,7 @@ Latency (`gen_ai.client.operation.duration`) and token type (`gen_ai.token.type`
 ## Prerequisites
 
 - Python 3.10+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - A Dynatrace API token with:
   - `openTelemetryTrace.ingest` — for traces and prompts
   - `metrics.ingest` — for latency charts and cost dashboard

--- a/microsoft-agent-framework/opentelemetry/README.md
+++ b/microsoft-agent-framework/opentelemetry/README.md
@@ -19,6 +19,9 @@ Prompt and completion content (`gen_ai.input.messages` / `gen_ai.output.messages
 
 Latency (`gen_ai.client.operation.duration`) and token type (`gen_ai.token.type`) are emitted as OTel **metrics** and require a separate metrics endpoint to populate the latency and cost dashboard views in Dynatrace.
 
+> [!NOTE]
+> This example is not supported on Windows. `agent-framework`'s dependency tree includes `azure-search-documents==11.7.0b2` which is unavailable on PyPI for Python 3.14+ on Windows.
+
 ## Prerequisites
 
 - Python 3.10+

--- a/microsoft-agent-framework/opentelemetry/pyproject.toml
+++ b/microsoft-agent-framework/opentelemetry/pyproject.toml
@@ -12,3 +12,4 @@ dependencies = [
 
 [tool.uv]
 environments = ["sys_platform != 'win32'"]
+prerelease = "allow"

--- a/microsoft-agent-framework/opentelemetry/pyproject.toml
+++ b/microsoft-agent-framework/opentelemetry/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "microsoft-agent-framework-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "agent-framework",
+    "agent-framework-openai",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+    "python-dotenv",
+]

--- a/microsoft-agent-framework/opentelemetry/pyproject.toml
+++ b/microsoft-agent-framework/opentelemetry/pyproject.toml
@@ -9,3 +9,6 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http",
     "python-dotenv",
 ]
+
+[tool.uv]
+environments = ["sys_platform != 'win32'"]

--- a/mistral/oneagent/Makefile
+++ b/mistral/oneagent/Makefile
@@ -5,7 +5,6 @@ export
 APP_IMAGE        ?=
 BUILD_PLATFORM   ?= linux/amd64
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -13,10 +12,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
 	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .

--- a/mistral/oneagent/README.md
+++ b/mistral/oneagent/README.md
@@ -5,6 +5,7 @@ Demonstrates tracing Mistral AI SDK API calls with Dynatrace via OneAgent auto-i
 ## Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Mistral API key (`MISTRAL_API_KEY`)
 - Dynatrace OneAgent installed on the host
 

--- a/mistral/oneagent/pyproject.toml
+++ b/mistral/oneagent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "mistral-oneagent-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "mistralai==2.4.13",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+]

--- a/ollama/oneagent/Makefile
+++ b/ollama/oneagent/Makefile
@@ -5,7 +5,6 @@ export
 APP_IMAGE        ?=
 BUILD_PLATFORM   ?= linux/amd64
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -13,10 +12,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
 	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .

--- a/ollama/oneagent/README.md
+++ b/ollama/oneagent/README.md
@@ -5,6 +5,7 @@ Demonstrates tracing Ollama SDK API calls with Dynatrace via OneAgent auto-instr
 ## Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Ollama running locally or accessible at `OLLAMA_HOST`
 - Dynatrace OneAgent installed on the host
 

--- a/ollama/oneagent/pyproject.toml
+++ b/ollama/oneagent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "ollama-oneagent-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "ollama>=0.3.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+]

--- a/openai-agents/opentelemetry/Makefile
+++ b/openai-agents/opentelemetry/Makefile
@@ -3,7 +3,6 @@ SHELL            := /bin/bash
 export
 
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -11,10 +10,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn api:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn api:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/openai-agents/opentelemetry/README.md
+++ b/openai-agents/opentelemetry/README.md
@@ -41,6 +41,7 @@ The token is read from the `DT_API_TOKEN` environment variable first, falling ba
 ### Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Azure OpenAI resource with a `gpt-4o` deployment
 - A Dynatrace environment with an API token scoped to `openTelemetryTrace.ingest` and `metrics.ingest`
 

--- a/openai-agents/opentelemetry/pyproject.toml
+++ b/openai-agents/opentelemetry/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "openai-agents-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "openai-agents",
+    "pydantic",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "traceloop-sdk",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+]

--- a/openai/oneagent/Makefile
+++ b/openai/oneagent/Makefile
@@ -5,7 +5,6 @@ export
 APP_IMAGE        ?=
 BUILD_PLATFORM   ?= linux/amd64
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -13,10 +12,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 run: ## Run app locally on port $(PORT)
-	$(PYTHON) -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
 	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .

--- a/openai/oneagent/README.md
+++ b/openai/oneagent/README.md
@@ -5,6 +5,7 @@ Demonstrates tracing OpenAI SDK API calls with Dynatrace via OneAgent auto-instr
 ## Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - OpenAI API key (`OPENAI_API_KEY`)
 - Dynatrace OneAgent installed on the host
 

--- a/openai/oneagent/pyproject.toml
+++ b/openai/oneagent/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "openai-oneagent-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=2.38.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+]

--- a/openai/openinference/Makefile
+++ b/openai/openinference/Makefile
@@ -12,8 +12,6 @@ DT_API_TOKEN        ?= dt0c01.*****
 APP_IMAGE           ?=
 BUILD_PLATFORM      ?= linux/amd64
 
-PYTHON              := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
-
 override COLLECTOR_IMAGE     := ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:0.50.0
 override COLLECTOR_CONTAINER := otel-collector
 
@@ -23,7 +21,7 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r requirements.txt
+	uv sync
 
 # ---------------------------------------------------------------------------
 # run: collector applies OpenInference → gen_ai.* transforms locally
@@ -38,7 +36,7 @@ run: ## Start collector (transform mode) + app  [no OpenPipeline needed]
 	@echo "Collector port is responding"
 	@OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 	  OTEL_EXPORTER_OTLP_HEADERS="" \
-	  $(PYTHON) app.py
+	  uv run python3 app.py
 
 # ---------------------------------------------------------------------------
 # run-openpipeline: app sends directly to Dynatrace — OpenPipeline transforms
@@ -48,7 +46,7 @@ run: ## Start collector (transform mode) + app  [no OpenPipeline needed]
 run-openpipeline: ## Run app directly to Dynatrace  [requires OpenPipeline in Dynatrace]
 	@OTEL_EXPORTER_OTLP_ENDPOINT=$(DT_ENDPOINT)/api/v2/otlp \
 	  OTEL_EXPORTER_OTLP_HEADERS="Authorization=Api-Token $(DT_API_TOKEN)" \
-	  $(PYTHON) app.py
+	  uv run python3 app.py
 
 # ---------------------------------------------------------------------------
 # Internal targets
@@ -89,7 +87,7 @@ push: ## Build and push container image to registry
 request: ## Run a haiku request through the running collector
 	@OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318 \
 	  OTEL_EXPORTER_OTLP_HEADERS="" \
-	  $(PYTHON) app.py
+	  uv run python3 app.py
 
 # ---------------------------------------------------------------------------
 # Utility

--- a/openai/openinference/README.md
+++ b/openai/openinference/README.md
@@ -36,6 +36,7 @@ OpenInference uses its own semantic conventions (`llm.model_name`, `llm.token_co
 - A Dynatrace tenant -- start a free trial at https://dt-url.net/trial
 - Docker installed and running (Option A only)
 - Python 3.8+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - An OpenAI-compatible API key and endpoint
 
 ---
@@ -91,11 +92,7 @@ source .env
 ### 3. Install dependencies
 
 ```bash
-# with make
 make install
-
-# or manually
-pip install -r requirements.txt
 ```
 
 ---

--- a/openai/openinference/pyproject.toml
+++ b/openai/openinference/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "openai-openinference-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "openai>=2.38.0",
+    "openinference-instrumentation-openai>=0.1.49",
+    "opentelemetry-sdk>=1.42.0",
+    "opentelemetry-exporter-otlp>=1.42.0",
+]

--- a/pydantic-ai/opentelemetry/Makefile
+++ b/pydantic-ai/opentelemetry/Makefile
@@ -3,7 +3,6 @@ SHELL            := /bin/bash
 export
 
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -11,10 +10,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies
-	$(PYTHON) -m pip install -r backend/requirements.txt
+	uv sync
 
 run: ## Run the Pydantic AI backend on port $(PORT)
-	PYTHONPATH=backend $(PYTHON) -m uvicorn backend.main:app --host 0.0.0.0 --port $(PORT)
+	PYTHONPATH=backend uv run python3 -m uvicorn backend.main:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/pydantic-ai/opentelemetry/README.md
+++ b/pydantic-ai/opentelemetry/README.md
@@ -79,6 +79,7 @@ An outer `music_agent.ask` span (kind `SERVER`) adds API-level context including
 ### Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - AWS credentials with access to Bedrock (Claude models in `us-east-1`)
 - Azure OpenAI endpoint and deployment (optional — falls back to Bedrock if unreachable)
 - A Dynatrace environment with an API token that has the following scopes:
@@ -108,16 +109,13 @@ AZURE_OPENAI_API_VERSION=2024-02-01
 ### Install dependencies
 
 ```bash
-cd pydantic/backend
-python3 -m venv .venv
-source .venv/bin/activate
-pip install -r requirements.txt
+make install
 ```
 
 ### Run the app
 
 ```bash
-python main.py
+make run
 ```
 
 The app is available at [http://localhost:8000](http://localhost:8000).

--- a/pydantic-ai/opentelemetry/pyproject.toml
+++ b/pydantic-ai/opentelemetry/pyproject.toml
@@ -3,7 +3,7 @@ name = "pydantic-ai-opentelemetry-demo"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic-ai",
+    "pydantic-ai>=1.0.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "python-dotenv",

--- a/pydantic-ai/opentelemetry/pyproject.toml
+++ b/pydantic-ai/opentelemetry/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "pydantic-ai-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic-ai",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+    "python-dotenv",
+    "boto3",
+    "openai>=1.58.0",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+]

--- a/rum/opentelemetry/Makefile
+++ b/rum/opentelemetry/Makefile
@@ -3,7 +3,6 @@ SHELL            := /bin/bash
 export
 
 PORT             ?= 8000
-PYTHON           := $(shell [ -f .venv/bin/python ] && echo .venv/bin/python || echo python3)
 
 .PHONY: install run build push request help
 
@@ -11,10 +10,10 @@ help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
 install: ## Install Python dependencies for backend
-	$(PYTHON) -m pip install -r backend/requirements.txt
+	uv sync
 
 run: ## Run the backend on port $(PORT)
-	cd backend && $(PYTHON) -m uvicorn main:app --host 0.0.0.0 --port $(PORT)
+	cd backend && uv run python3 -m uvicorn main:app --host 0.0.0.0 --port $(PORT)
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/rum/opentelemetry/README.md
+++ b/rum/opentelemetry/README.md
@@ -134,6 +134,7 @@ The "Copy for DQL" buttons in the UI write this query directly to your clipboard
 ### Prerequisites
 
 - Python 3.11+
+- [uv](https://docs.astral.sh/uv/getting-started/installation/)
 - Node.js 18+
 - A Dynatrace environment with RUM enabled
 - AWS Bedrock access (or Azure OpenAI)
@@ -175,9 +176,9 @@ All paths below are relative to the repo root.
 ### Option A — Vanilla HTML frontend (simplest)
 
 ```bash
-cd real-user-monitoring-frontends/backend
-pip install -r requirements.txt
-python main.py
+cd rum/opentelemetry
+make install
+make run
 ```
 
 Open **http://localhost:8000** — the FastAPI server serves the HTML file directly.
@@ -187,9 +188,9 @@ Open **http://localhost:8000** — the FastAPI server serves the HTML file direc
 Run the FastAPI backend first (it handles all AI calls):
 
 ```bash
-cd real-user-monitoring-frontends/backend
-pip install -r requirements.txt
-python main.py          # stays on :8000
+cd rum/opentelemetry
+make install
+make run   # stays on :8000
 ```
 
 In a second terminal, start the Next.js dev server:

--- a/rum/opentelemetry/pyproject.toml
+++ b/rum/opentelemetry/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "rum-opentelemetry-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "pydantic-ai",
+    "fastapi>=0.115.0",
+    "uvicorn[standard]>=0.30.0",
+    "python-dotenv",
+    "boto3",
+    "openai>=1.58.0",
+    "opentelemetry-sdk",
+    "opentelemetry-exporter-otlp-proto-http",
+]

--- a/rum/opentelemetry/pyproject.toml
+++ b/rum/opentelemetry/pyproject.toml
@@ -3,7 +3,7 @@ name = "rum-opentelemetry-demo"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "pydantic-ai",
+    "pydantic-ai>=1.0.0",
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.30.0",
     "python-dotenv",

--- a/test/e2e/audit_test.go
+++ b/test/e2e/audit_test.go
@@ -289,13 +289,13 @@ func statusIcon(status string) string {
 	}
 }
 
-// auditSpan polls DT until a span matching dql is found (3-minute timeout),
+// auditSpan polls DT until a span matching dql is found (5-minute timeout),
 // then fetches all spans in the same trace to build a complete attribute picture.
 // Writes JSON + markdown reports to test/e2e/reports/. Logs (but does NOT fail)
 // any required attribute gaps. The test fails only if no anchor span is found.
 func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)
@@ -324,7 +324,7 @@ func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string)
 // audits where the provider may not have been selected in the current run.
 func auditSpanOptional(t *testing.T, sdk, instrumentation string, p Profile, dql string) {
 	t.Helper()
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
 	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)


### PR DESCRIPTION
# Description

Replace venv + pip with uv across all Python projects in the repo for a consistent developer experience.

  What changed:
  - Added pyproject.toml to every Python project (replaces requirements.txt)
  - Updated every Makefile: make install runs uv sync, make run uses uv run
  - Updated every README: prerequisites now list uv instead of Python venv steps

  Notable fixes:
  - litellm: declared litellm[proxy] extras to pull in the full proxy dependency group (backoff, websockets, etc.)
  - pydantic-ai / rum: pinned pydantic-ai>=1.0.0 — uv was silently resolving the old pre-1.0 release which lacked InstrumentationSettings
  - microsoft-agent-framework: added prerelease = "allow" (the package has no stable release yet) and environments = ["sys_platform != 'win32'"]
  to skip a broken Azure Search dependency on Windows; added a compatibility note to the README
- added more time for ollama test before falure


e2e @ https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples/actions/runs/28358303295