### PR TITLE
chore: make sure test runs are discernable

### DIFF
--- a/test/e2e/audit_test.go
+++ b/test/e2e/audit_test.go
@@ -302,6 +302,12 @@ func assertNotErrorSpan(t *testing.T, span map[string]interface{}) {
 	}
 }
 
+// scopedDQL appends a test.run.id filter so DQL only returns spans from this
+// specific test run, preventing interference between concurrent pipeline runs.
+func scopedDQL(dql string) string {
+	return dql + fmt.Sprintf("\n| filter test.run.id == %q", testRunID)
+}
+
 // auditSpan polls DT until a span matching dql is found (5-minute timeout),
 // then fetches all spans in the same trace to build a complete attribute picture.
 // Writes JSON + markdown reports to test/e2e/reports/. Logs (but does NOT fail)
@@ -312,7 +318,7 @@ func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string,
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)
+	records, err := dtClient.PollUntilSpans(ctx, scopedDQL(dql), 15*time.Second)
 	if err != nil {
 		t.Fatalf("poll DT spans: %v", err)
 	}
@@ -346,7 +352,7 @@ func auditSpanOptional(t *testing.T, sdk, instrumentation string, p Profile, dql
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	records, err := dtClient.PollUntilSpans(ctx, dql, 15*time.Second)
+	records, err := dtClient.PollUntilSpans(ctx, scopedDQL(dql), 15*time.Second)
 	if err != nil || len(records) == 0 {
 		t.Skipf("no %s/%s spans found — provider likely not selected this run", sdk, instrumentation)
 		return

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -1,15 +1,32 @@
 package e2e
 
 import (
+	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples/test/e2e/internal/dynatrace"
 )
 
 var dtClient *dynatrace.Client
 
+// testRunID is a unique identifier for this test run, injected into every app
+// as an OTEL resource attribute so DQL queries are scoped to spans from this
+// run only — preventing interference between concurrent or recent pipeline runs.
+var testRunID string
+
 func TestMain(m *testing.M) {
+	testRunID = fmt.Sprintf("%d", time.Now().UnixNano())
+	// Propagate to all child processes started by startApp/startCLIApp.
+	// The OTel SDK merges OTEL_RESOURCE_ATTRIBUTES automatically into the resource.
+	existing := os.Getenv("OTEL_RESOURCE_ATTRIBUTES")
+	runAttr := "test.run.id=" + testRunID
+	if existing != "" {
+		runAttr = existing + "," + runAttr
+	}
+	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", runAttr)
+
 	dtClient = dynatrace.New(mustEnv("DT_APPS_ENDPOINT"), mustEnv("DT_API_TOKEN"))
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
# Description

To avoid dql queries between test run to falsify results we need to distinguish separate runs spans and only evaluate those, parallel runs would otherwise hide issues in tests.

https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples/actions/runs/28497417701/job/84466562242

<img width="2594" height="892" alt="image" src="https://github.com/user-attachments/assets/450ee0de-d515-40b4-b422-d3e2d8d05bc8" />

