### PR TITLE
remove oneagent-sdk explicit init, add agent name for smartscape topology

### DIFF
--- a/anthropic/oneagent/.env.sample
+++ b/anthropic/oneagent/.env.sample
@@ -2,3 +2,8 @@ AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=
 ANTHROPIC_MODEL_ID=
+
+# Agent name shown in the Dynatrace AI Observability smartscape topology.
+# OneAgent reads OTEL_RESOURCE_ATTRIBUTES and merges them into span attributes.
+# Change this to any name that describes what this app does.
+OTEL_RESOURCE_ATTRIBUTES=gen_ai.agent.name=anthropic-haiku-writer

--- a/anthropic/oneagent/main.py
+++ b/anthropic/oneagent/main.py
@@ -2,12 +2,6 @@ import os
 
 import anthropic
 
-
-def setup_instrumentation() -> None:
-    import oneagent
-    oneagent.initialize()
-
-
 _client = None
 
 

--- a/anthropic/oneagent/pyproject.toml
+++ b/anthropic/oneagent/pyproject.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 requires-python = ">=3.13"
 dependencies = [
     "anthropic[bedrock]",
-    "oneagent-sdk",
     "fastapi",
     "uvicorn[standard]",
 ]

--- a/anthropic/oneagent/requirements.txt
+++ b/anthropic/oneagent/requirements.txt
@@ -1,2 +1,1 @@
 anthropic[bedrock]
-oneagent-sdk

--- a/anthropic/oneagent/server.py
+++ b/anthropic/oneagent/server.py
@@ -4,9 +4,7 @@ import os
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from main import setup_instrumentation, write_haiku
-
-setup_instrumentation()
+from main import write_haiku
 
 app = FastAPI(title="Haiku Writer")
 

--- a/anthropic/oneagent/uv.lock
+++ b/anthropic/oneagent/uv.lock
@@ -294,7 +294,6 @@ source = { virtual = "." }
 dependencies = [
     { name = "anthropic", extra = ["bedrock"] },
     { name = "fastapi" },
-    { name = "oneagent-sdk" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -302,20 +301,7 @@ dependencies = [
 requires-dist = [
     { name = "anthropic", extras = ["bedrock"] },
     { name = "fastapi" },
-    { name = "oneagent-sdk" },
     { name = "uvicorn", extras = ["standard"] },
-]
-
-[[package]]
-name = "oneagent-sdk"
-version = "1.5.2.20260107.153442"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/64/1e/fe86ee1f42b0a97576e12ba447cb50fb2088c7f1d28d96c176b198ce4a68/oneagent_sdk-1.5.2.20260107.153442.tar.gz", hash = "sha256:6442ac5c1ec395f0e897516f8a25a012d85744d8f33bd9f7e2db9eac411b9179", size = 86340, upload-time = "2026-01-07T14:44:55.339Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/bb/34acae65e81f239e04ec3c9bbc4a560fc0e60bcd23b065e969466cd01235/oneagent_sdk-1.5.2.20260107.153442-py2.py3-none-manylinux1_i686.whl", hash = "sha256:b0e7aa9dc5dcb684e0f63adbf44521bb6082f3e445ab39ecb507f23e4cb44afd", size = 135690, upload-time = "2026-01-07T14:44:47.868Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/74/d40f29c5b1683dbf6fc5b322912ec07d54e1e5ddb74b05a8bd21fe7e693f/oneagent_sdk-1.5.2.20260107.153442-py2.py3-none-manylinux1_x86_64.whl", hash = "sha256:6c88204ca2ccb849bb2359a66a5b60af0b3eaede1b943111f99ef80138261d94", size = 138714, upload-time = "2026-01-07T14:44:49.68Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/88/44ae3b897b3035c36fbdd8f3b2267dc51e65bb1846ef659b5c61c55a6a72/oneagent_sdk-1.5.2.20260107.153442-py2.py3-none-win32.whl", hash = "sha256:2affdcc3278b2e9814d712222696eb44c6cd02c2bc03aadca33bba422efc65fd", size = 217376, upload-time = "2026-01-07T14:44:50.936Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/cc/007099186dc324aca7bb19bd45188f79182987926363a30638bb2309867a/oneagent_sdk-1.5.2.20260107.153442-py2.py3-none-win_amd64.whl", hash = "sha256:4a5efd48cde1295086822a00a1aa8769cdbd744b7e2776135ebf106ffe5b10f3", size = 254633, upload-time = "2026-01-07T14:44:54.199Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Removes `oneagent-sdk` dependency and the `setup_instrumentation()` / `oneagent.initialize()` boilerplate from `anthropic/oneagent`. OneAgent instrumentation is zero-code — the SDK is injected by the host agent, no explicit initialization needed in application code.
- Adds `OTEL_RESOURCE_ATTRIBUTES=gen_ai.agent.name=anthropic-haiku-writer` to `.env.sample`. OneAgent reads `OTEL_RESOURCE_ATTRIBUTES` and merges them into span attributes, which creates a `GENAI_AGENT` entity and connects the service in the Dynatrace AI Observability smartscape topology.

## Test plan

- [ ] Run `make install && make run` locally — app starts without errors
- [ ] POST `/haiku` returns a haiku
- [ ] In Dynatrace AI Observability, confirm `anthropic-haiku-writer` GENAI_AGENT node appears connected to `anthropic/oneagent` service in smartscape topology

🤖 Generated with [Claude Code](https://claude.com/claude-code)