### PR TITLE
group opentelemetry-js packages in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", "monorepo:opentelemetry-js"],
   "timezone": "UTC",
   "schedule": ["before 5am on Monday"],
   "ignorePaths": ["**/.venv/**"],


### PR DESCRIPTION
## Summary
- PR #114 bumped `@opentelemetry/sdk-trace-base` to `^2.0.0` in `langfuse/opentelemetry-node/package.json` without also bumping `@opentelemetry/sdk-node`/`@opentelemetry/exporter-trace-otlp-proto`, which still pulled `sdk-trace-base@1.x` internally — producing two incompatible `Span`/`ReadableSpan` types and breaking the build (fixed in #123).
- Renovate proposed these as separate, independently-timed updates because nothing grouped the `@opentelemetry/*` family together, so they landed in different branches/commits.
- Added the built-in `monorepo:opentelemetry-js` preset, which groups all packages published from the `open-telemetry/opentelemetry-js` repo (api, sdk-node, sdk-trace-base, exporter-trace-otlp-proto, etc.) into a single PR, so they always bump in lockstep going forward.

## Test plan
- [x] Validated with `npx --package renovate -- renovate-config-validator .github/renovate.json` — "Config validated successfully"