### PR TITLE
add nightly E2E alert notifications

### DIFF
--- a/.github/scripts/notify-nightly.sh
+++ b/.github/scripts/notify-nightly.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Called by the notify job in e2e.yml after nightly runs complete.
+# Alerts on two independent conditions:
+#   1. Job failure (no spans found — t.Fatalf in test)
+#   2. Attribute regression (attribute present before, missing now)
 # Required env: GH_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID,
 #               CURRENT_ONEAGENT, CURRENT_OTELCOL
 set -euo pipefail
@@ -8,19 +11,12 @@ REPO="${GITHUB_REPOSITORY}"
 CURRENT_RUN_ID="${GITHUB_RUN_ID}"
 RUN_URL="https://github.com/${REPO}/actions/runs/${CURRENT_RUN_ID}"
 
-# Determine overall current status
-CURRENT_STATUS="success"
+# --- Job-level failure check ---
 FAILING_JOBS=""
-if [ "$CURRENT_ONEAGENT" = "failure" ]; then
-  CURRENT_STATUS="failure"
-  FAILING_JOBS="oneagent-nightly"
-fi
-if [ "$CURRENT_OTELCOL" = "failure" ]; then
-  CURRENT_STATUS="failure"
-  FAILING_JOBS="${FAILING_JOBS:+$FAILING_JOBS, }otelcol"
-fi
+[ "${CURRENT_ONEAGENT:-}" = "failure" ] && FAILING_JOBS="oneagent-nightly"
+[ "${CURRENT_OTELCOL:-}"  = "failure" ] && FAILING_JOBS="${FAILING_JOBS:+$FAILING_JOBS, }otelcol"
 
-# Fetch previous completed nightly run id + conclusion
+# --- Attribute diff ---
 PREV_RUN=$(gh api \
   "repos/${REPO}/actions/workflows/e2e.yml/runs?event=schedule&status=completed&per_page=5" \
   --jq ".workflow_runs[] | select(.id != ${CURRENT_RUN_ID}) | {id: .id, conclusion: .conclusion}" \
@@ -29,30 +25,14 @@ PREV_RUN_ID=$(echo "$PREV_RUN" | jq -r '.id // empty')
 PREV_CONCLUSION=$(echo "$PREV_RUN" | jq -r '.conclusion // empty')
 
 echo "Previous nightly run: ${PREV_RUN_ID:-unknown} (${PREV_CONCLUSION:-unknown})"
-echo "Current nightly status: ${CURRENT_STATUS}"
 echo "Failing jobs: ${FAILING_JOBS:-none}"
 
-# Determine event type
-EVENT_TYPE=""
-if [ "$CURRENT_STATUS" = "failure" ] && [ "$PREV_CONCLUSION" = "success" ]; then
-  EVENT_TYPE="regression"
-elif [ "$CURRENT_STATUS" = "success" ] && [ "$PREV_CONCLUSION" = "failure" ]; then
-  EVENT_TYPE="recovery"
-fi
-
-if [ -z "$EVENT_TYPE" ]; then
-  echo "No state change detected. Skipping."
-  exit 0
-fi
-
-# Build attribute diff table by comparing JSON audit reports
-DIFF_SECTION=""
+DIFF_ROWS=""
 if [ -n "${PREV_RUN_ID:-}" ]; then
   mkdir -p curr-reports prev-reports
   gh run download "$CURRENT_RUN_ID" --dir curr-reports --repo "${REPO}" 2>/dev/null || true
   gh run download "$PREV_RUN_ID"    --dir prev-reports --repo "${REPO}" 2>/dev/null || true
 
-  DIFF_ROWS=""
   while IFS= read -r curr_file; do
     filename=$(basename "$curr_file")
     prev_file=$(find prev-reports -name "$filename" | head -1)
@@ -74,33 +54,58 @@ if [ -n "${PREV_RUN_ID:-}" ]; then
 
     DIFF_ROWS="${DIFF_ROWS}${ROWS}"$'\n'
   done < <(find curr-reports -name "*.json")
-
-  if [ -n "${DIFF_ROWS// /}" ]; then
-    DIFF_SECTION=$'\n\n## Attribute regressions\n\n| Suite | Attribute | Before | Now |\n|-------|-----------|--------|-----|\n'"${DIFF_ROWS}"
-  else
-    DIFF_SECTION=$'\n\n_No per-attribute diff available (reports missing or no attribute changes detected)._'
-  fi
 fi
 
-if [ "$EVENT_TYPE" = "regression" ]; then
-  BODY="$(printf '%b' "## Nightly E2E regression\n\nThe nightly run failed after a previously successful run.\n\n**Failing jobs:** ${FAILING_JOBS}\n**Run:** ${RUN_URL}\n**Previous conclusion:** \`${PREV_CONCLUSION}\`${DIFF_SECTION}")"
-  gh issue create \
-    --title "Nightly E2E regression: ${FAILING_JOBS}" \
-    --body "$BODY" \
-    --label "nightly-e2e-alert" \
-    --repo "${REPO}" || echo "Warning: failed to create GitHub issue"
+HAS_JOB_FAILURE=false
+[ -n "${FAILING_JOBS:-}" ] && HAS_JOB_FAILURE=true
+
+HAS_ATTR_REGRESSION=false
+[ -n "${DIFF_ROWS// /}" ] && HAS_ATTR_REGRESSION=true
+
+echo "Job failure: ${HAS_JOB_FAILURE} | Attribute regression: ${HAS_ATTR_REGRESSION}"
+
+OPEN_ISSUE=$(gh issue list \
+  --label "nightly-e2e-alert" \
+  --state open \
+  --json number \
+  --jq '.[0].number' \
+  --repo "${REPO}" || true)
+
+# Build issue body sections
+BODY_PARTS=""
+
+if [ "$HAS_JOB_FAILURE" = "true" ]; then
+  BODY_PARTS="${BODY_PARTS}$(printf '%b' "## Test failure\n\nOne or more jobs failed (no spans received).\n\n**Failing jobs:** ${FAILING_JOBS}\n")"
+fi
+
+if [ "$HAS_ATTR_REGRESSION" = "true" ]; then
+  ATTR_TABLE="$(printf '%b' "\n## Attribute regressions\n\nOne or more attributes present in the previous run are now missing.\n\n| Suite | Attribute | Before | Now |\n|-------|-----------|--------|-----|\n${DIFF_ROWS}")"
+  BODY_PARTS="${BODY_PARTS}${ATTR_TABLE}"
+fi
+
+if [ "$HAS_JOB_FAILURE" = "true" ] || [ "$HAS_ATTR_REGRESSION" = "true" ]; then
+  BODY="$(printf '%b' "**Run:** ${RUN_URL}\n**Previous run:** ${PREV_RUN_ID:-unknown}\n\n${BODY_PARTS}")"
+
+  if [ -n "${OPEN_ISSUE:-}" ]; then
+    gh issue comment "$OPEN_ISSUE" \
+      --body "$BODY" \
+      --repo "${REPO}" || echo "Warning: failed to comment on GitHub issue"
+  else
+    TITLE="Nightly E2E alert"
+    [ "$HAS_JOB_FAILURE" = "true" ] && [ "$HAS_ATTR_REGRESSION" = "false" ] && TITLE="Nightly E2E test failure: ${FAILING_JOBS}"
+    [ "$HAS_JOB_FAILURE" = "false" ] && [ "$HAS_ATTR_REGRESSION" = "true" ]  && TITLE="Nightly E2E attribute regression"
+    gh issue create \
+      --title "$TITLE" \
+      --body "$BODY" \
+      --label "nightly-e2e-alert" \
+      --repo "${REPO}" || echo "Warning: failed to create GitHub issue"
+  fi
 else
-  OPEN_ISSUE=$(gh issue list \
-    --label "nightly-e2e-alert" \
-    --state open \
-    --json number \
-    --jq '.[0].number' \
-    --repo "${REPO}" || true)
   if [ -n "${OPEN_ISSUE:-}" ]; then
     gh issue close "$OPEN_ISSUE" \
-      --comment "$(printf '%b' "## Nightly E2E recovered\n\nThe nightly run is green again.\n\n**Run:** ${RUN_URL}\n**Previous conclusion:** \`${PREV_CONCLUSION}\`")" \
+      --comment "$(printf '%b' "## Nightly E2E recovered\n\nAll tests pass and all previously missing attributes are present again.\n\n**Run:** ${RUN_URL}")" \
       --repo "${REPO}" || echo "Warning: failed to close GitHub issue"
   else
-    echo "No open nightly-e2e-alert issue found to close."
+    echo "All clear. No open issue to close."
   fi
 fi

--- a/.github/scripts/notify-nightly.sh
+++ b/.github/scripts/notify-nightly.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Called by the notify job in e2e.yml after nightly runs complete.
+# Required env: GH_TOKEN, GITHUB_REPOSITORY, GITHUB_RUN_ID,
+#               CURRENT_ONEAGENT, CURRENT_OTELCOL
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY}"
+CURRENT_RUN_ID="${GITHUB_RUN_ID}"
+RUN_URL="https://github.com/${REPO}/actions/runs/${CURRENT_RUN_ID}"
+
+# Determine overall current status
+CURRENT_STATUS="success"
+FAILING_JOBS=""
+if [ "$CURRENT_ONEAGENT" = "failure" ]; then
+  CURRENT_STATUS="failure"
+  FAILING_JOBS="oneagent-nightly"
+fi
+if [ "$CURRENT_OTELCOL" = "failure" ]; then
+  CURRENT_STATUS="failure"
+  FAILING_JOBS="${FAILING_JOBS:+$FAILING_JOBS, }otelcol"
+fi
+
+# Fetch previous completed nightly run id + conclusion
+PREV_RUN=$(gh api \
+  "repos/${REPO}/actions/workflows/e2e.yml/runs?event=schedule&status=completed&per_page=5" \
+  --jq ".workflow_runs[] | select(.id != ${CURRENT_RUN_ID}) | {id: .id, conclusion: .conclusion}" \
+  | head -1 || true)
+PREV_RUN_ID=$(echo "$PREV_RUN" | jq -r '.id // empty')
+PREV_CONCLUSION=$(echo "$PREV_RUN" | jq -r '.conclusion // empty')
+
+echo "Previous nightly run: ${PREV_RUN_ID:-unknown} (${PREV_CONCLUSION:-unknown})"
+echo "Current nightly status: ${CURRENT_STATUS}"
+echo "Failing jobs: ${FAILING_JOBS:-none}"
+
+# Determine event type
+EVENT_TYPE=""
+if [ "$CURRENT_STATUS" = "failure" ] && [ "$PREV_CONCLUSION" = "success" ]; then
+  EVENT_TYPE="regression"
+elif [ "$CURRENT_STATUS" = "success" ] && [ "$PREV_CONCLUSION" = "failure" ]; then
+  EVENT_TYPE="recovery"
+fi
+
+if [ -z "$EVENT_TYPE" ]; then
+  echo "No state change detected. Skipping."
+  exit 0
+fi
+
+# Build attribute diff table by comparing JSON audit reports
+DIFF_SECTION=""
+if [ -n "${PREV_RUN_ID:-}" ]; then
+  mkdir -p curr-reports prev-reports
+  gh run download "$CURRENT_RUN_ID" --dir curr-reports --repo "${REPO}" 2>/dev/null || true
+  gh run download "$PREV_RUN_ID"    --dir prev-reports --repo "${REPO}" 2>/dev/null || true
+
+  DIFF_ROWS=""
+  while IFS= read -r curr_file; do
+    filename=$(basename "$curr_file")
+    prev_file=$(find prev-reports -name "$filename" | head -1)
+    [ -f "$prev_file" ] || continue
+
+    ROWS=$(jq -r '
+      def was_ok: test("^(pass|pass_via_fallback|present|present_via_fallback)$");
+      def is_bad: test("^(fail|absent)$");
+      . as $curr |
+      input as $prev |
+      ($prev.required + $prev.optional) as $prev_attrs |
+      ($curr.required  + $curr.optional)  as $curr_attrs |
+      $curr_attrs[] |
+      . as $c |
+      ($prev_attrs[] | select(.attribute == $c.attribute)) as $p |
+      select(($p.status | was_ok) and ($c.status | is_bad)) |
+      "| `\($curr.sdk)/\($curr.instrumentation)` | `\(.attribute)` | \($p.status) | \($c.status) |"
+    ' "$curr_file" "$prev_file" 2>/dev/null || true)
+
+    DIFF_ROWS="${DIFF_ROWS}${ROWS}"$'\n'
+  done < <(find curr-reports -name "*.json")
+
+  if [ -n "${DIFF_ROWS// /}" ]; then
+    DIFF_SECTION=$'\n\n## Attribute regressions\n\n| Suite | Attribute | Before | Now |\n|-------|-----------|--------|-----|\n'"${DIFF_ROWS}"
+  else
+    DIFF_SECTION=$'\n\n_No per-attribute diff available (reports missing or no attribute changes detected)._'
+  fi
+fi
+
+if [ "$EVENT_TYPE" = "regression" ]; then
+  BODY="$(printf '%b' "## Nightly E2E regression\n\nThe nightly run failed after a previously successful run.\n\n**Failing jobs:** ${FAILING_JOBS}\n**Run:** ${RUN_URL}\n**Previous conclusion:** \`${PREV_CONCLUSION}\`${DIFF_SECTION}")"
+  gh issue create \
+    --title "Nightly E2E regression: ${FAILING_JOBS}" \
+    --body "$BODY" \
+    --label "nightly-e2e-alert" \
+    --repo "${REPO}" || echo "Warning: failed to create GitHub issue"
+else
+  OPEN_ISSUE=$(gh issue list \
+    --label "nightly-e2e-alert" \
+    --state open \
+    --json number \
+    --jq '.[0].number' \
+    --repo "${REPO}" || true)
+  if [ -n "${OPEN_ISSUE:-}" ]; then
+    gh issue close "$OPEN_ISSUE" \
+      --comment "$(printf '%b' "## Nightly E2E recovered\n\nThe nightly run is green again.\n\n**Run:** ${RUN_URL}\n**Previous conclusion:** \`${PREV_CONCLUSION}\`")" \
+      --repo "${REPO}" || echo "Warning: failed to close GitHub issue"
+  else
+    echo "No open nightly-e2e-alert issue found to close."
+  fi
+fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -389,6 +389,11 @@ jobs:
             sudo /opt/dynatrace/oneagent/agent/uninstall.sh
           fi
 
+      # TEMP: force job failure to test notify logic — remove before merging
+      - name: Force failure for notify test
+        if: always()
+        run: exit 1
+
   otelcol:
     name: E2E / ${{ matrix.name }}
     needs: filter
@@ -475,14 +480,17 @@ jobs:
   notify:
     name: Notify on regression or recovery
     needs: [oneagent-nightly, otelcol]
-    if: always() && github.event_name == 'schedule'
+    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') # TEMP: remove workflow_dispatch before merging
     runs-on: ubuntu-latest
     permissions:
       issues: write
       actions: read
       contents: read
     steps:
-      - name: Create issue on regression or recovery
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Diff audit reports and notify
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CURRENT_ONEAGENT: ${{ needs.oneagent-nightly.result }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -471,3 +471,20 @@ jobs:
           name: span-audit-reports-${{ matrix.name }}
           path: test/e2e/reports/
           retention-days: 30
+
+  notify:
+    name: Notify on regression or recovery
+    needs: [oneagent-nightly, otelcol]
+    if: always() && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      actions: read
+      contents: read
+    steps:
+      - name: Create issue on regression or recovery
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_ONEAGENT: ${{ needs.oneagent-nightly.result }}
+          CURRENT_OTELCOL: ${{ needs.otelcol.result }}
+        run: bash .github/scripts/notify-nightly.sh

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -389,11 +389,6 @@ jobs:
             sudo /opt/dynatrace/oneagent/agent/uninstall.sh
           fi
 
-      # TEMP: force job failure to test notify logic — remove before merging
-      - name: Force failure for notify test
-        if: always()
-        run: exit 1
-
   otelcol:
     name: E2E / ${{ matrix.name }}
     needs: filter
@@ -480,7 +475,7 @@ jobs:
   notify:
     name: Notify on regression or recovery
     needs: [oneagent-nightly, otelcol]
-    if: always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') # TEMP: remove workflow_dispatch before merging
+    if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
## Summary

- Adds a `notify` job to the nightly E2E workflow that runs after `oneagent-nightly` and `otelcol`
- On regression (prev=success → curr=failure): creates a GitHub issue with label `nightly-e2e-alert` and a per-attribute diff table showing which attributes were present before but are now missing
- On recovery (prev=failure → curr=success): closes the open `nightly-e2e-alert` issue with a recovery comment
- No alert when the status is unchanged (stable pass or stable fail)

## Test plan

- [x] Create label `nightly-e2e-alert` in the repo: `gh label create "nightly-e2e-alert" --color "D93F0B" --repo dynatrace-oss/dynatrace-ai-agent-instrumentation-examples`
- [x] Subscribe the Slack channel: `/github subscribe dynatrace-oss/dynatrace-ai-agent-instrumentation-examples issues +label:"nightly-e2e-alert"` in `#int-team-ai-observability-github-notifications`
- [ ] Trigger a manual `workflow_dispatch` run and verify `notify` job skips (not a schedule event)
- [ ] Wait for next nightly run or manually test by temporarily forcing a job failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)