### PR TITLE
document experimental sensor limitation in groq, cohere, ollama oneagent readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ Monitor specific AI provider SDKs with Dynatrace.
 |----------|----------|---------------|---------------|
 | [AWS Bedrock](./aws-bedrock/) | [✓](./aws-bedrock/oneagent/) | [✓](./aws-bedrock/openinference/) | [✓](./aws-bedrock/opentelemetry/) |
 | [Anthropic](./anthropic/oneagent/) | [✓](./anthropic/oneagent/) | — | — |
-| [Cohere](./cohere/oneagent/) | [✓](./cohere/oneagent/) | — | — |
-| [Groq](./groq/oneagent/) | [✓](./groq/oneagent/) | — | — |
-| [Mistral](./mistral/oneagent/) | [✓](./mistral/oneagent/) | — | — |
-| [Ollama](./ollama/oneagent/) | [✓](./ollama/oneagent/) | — | — |
+| [Cohere](./cohere/oneagent/) | [✓\*](./cohere/oneagent/) | — | — |
+| [Groq](./groq/oneagent/) | [✓\*](./groq/oneagent/) | — | — |
+| [Mistral](./mistral/oneagent/) | [✓\*](./mistral/oneagent/) | — | — |
+| [Ollama](./ollama/oneagent/) | [✓\*](./ollama/oneagent/) | — | — |
 | [OpenAI](./openai/) | [✓](./openai/oneagent/) | [✓](./openai/openinference/) | — |
+
+\* Experimental sensor — prompt input and output capture not yet supported.
 
 ### Agent Framework Demos
 

--- a/cohere/oneagent/README.md
+++ b/cohere/oneagent/README.md
@@ -2,6 +2,8 @@
 
 Demonstrates tracing Cohere SDK API calls with Dynatrace via OneAgent auto-instrumentation.
 
+> **Experimental sensor** — Enables monitoring of Cohere SDK calls in Python applications. Prompt input and output capture is not supported yet.
+
 ## Prerequisites
 
 - Python 3.11+

--- a/groq/oneagent/README.md
+++ b/groq/oneagent/README.md
@@ -2,6 +2,8 @@
 
 Demonstrates tracing Groq SDK API calls with Dynatrace via OneAgent auto-instrumentation.
 
+> **Experimental sensor** — Enables monitoring of Groq SDK calls in Python applications. Prompt input and output capture is not supported yet.
+
 ## Prerequisites
 
 - Python 3.11+

--- a/ollama/oneagent/README.md
+++ b/ollama/oneagent/README.md
@@ -2,6 +2,8 @@
 
 Demonstrates tracing Ollama SDK API calls with Dynatrace via OneAgent auto-instrumentation.
 
+> **Experimental sensor** — Enables monitoring of Ollama SDK calls in Python applications. Prompt input and output capture is not supported yet.
+
 ## Prerequisites
 
 - Python 3.11+


### PR DESCRIPTION
Adds a consistent experimental sensor disclaimer to the oneagent READMEs that do not support prompt input/output capture yet, and marks them in the main README table.

## Changes

- **`groq/oneagent/README.md`** — add experimental sensor note
- **`cohere/oneagent/README.md`** — add experimental sensor note
- **`ollama/oneagent/README.md`** — add experimental sensor note
- **`README.md`** — mark experimental sensors with `*` in the provider table with a footnote

## Which sensors support prompt capture?

| Sensor | Prompt capture |
|--------|---------------|
| OpenAI | ✅ |
| AWS Bedrock (incl. Anthropic, Strands, AgentCore) | ✅ |
| Haystack (via OpenAI sensor) | ✅ |
| Groq | ❌ experimental |
| Cohere | ❌ experimental |
| Ollama | ❌ experimental |
| Mistral | ❌ experimental (documented in #125) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)