### PR TITLE
remove redundant renovate schedule so updates aren't stuck awaiting schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", "monorepo:opentelemetry-js"],
   "timezone": "UTC",
-  "schedule": ["before 5am on Monday"],
   "ignorePaths": ["**/.venv/**"],
   "customManagers": [
     {


### PR DESCRIPTION
## Problem

Renovate detects updates but they get stuck in the Dependency Dashboard (#90) under **"Awaiting Schedule"** and never become PRs.

Concrete example: the OpenTelemetry collector bump to **v0.52.0** (released 2026-07-13, image tag confirmed present on ghcr) has been sitting under "Awaiting Schedule" while all `Makefile`s stay pinned to `0.51.0`.

## Root cause

Timing was double-gated:

- **Workflow cron** — `.github/workflows/renovate.yml` runs Renovate `0 4 * * 1` (Mon 04:00 UTC).
- **Internal schedule** — `renovate.json` also had `"schedule": ["before 5am on Monday"]`.

GitHub Actions scheduled runs are routinely delayed by several minutes. The 2026-07-20 run actually started at **05:11 UTC** — past the `before 5am` window. Renovate still ran and extracted updates, but deferred every new PR as "awaiting schedule," so nothing landed. This recurs each week whenever the runner is delayed past 05:00.

## Fix

Remove the redundant internal `schedule`. The workflow cron already controls *when* Renovate runs, so it becomes the single source of timing and Renovate opens PRs on every run.

## Follow-up

To unblock the queued v0.52.0 bump immediately, tick its checkbox on the Dependency Dashboard (#90) or trigger the Renovate workflow via `workflow_dispatch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)