### PR TITLE
Make DT_ENDPOINT include the /api/v2/otlp base path for consistency

### DIFF
--- a/rum/opentelemetry/.env_example
+++ b/rum/opentelemetry/.env_example
@@ -1,4 +1,4 @@
-DT_ENDPOINT=https://<your-env-id>.live.dynatrace.com # Link to your environment, e.g. https://abc12345.live.dynatrace.com/
+DT_ENDPOINT=https://<your-env-id>.live.dynatrace.com/api/v2/otlp # OTLP base URL, e.g. https://abc12345.live.dynatrace.com/api/v2/otlp
 DT_API_TOKEN=dt0c01.<your-token>          # scopes: openTelemetryTrace.ingest, metrics.ingest
 DT_RUM_SCRIPT=https://js-cdn.dynatrace.com/jstag/<your-tag>.js  # RUM JS tag URL from Experience Vitals setup
 

--- a/rum/opentelemetry/README.md
+++ b/rum/opentelemetry/README.md
@@ -227,7 +227,7 @@ Clicking on your frontend reveals the full RUM overview — user action duration
 Create a `.env` file in `rum/opentelemetry/`:
 
 ```bash
-DT_ENDPOINT=https://<your-env-id>.live.dynatrace.com
+DT_ENDPOINT=https://<your-env-id>.live.dynatrace.com/api/v2/otlp
 DT_API_TOKEN=dt0c01.<your-token>          # scopes: openTelemetryTrace.ingest, metrics.ingest
 DT_RUM_SCRIPT=https://js-cdn.dynatrace.com/jstag/<your-tag>.js
 

--- a/rum/opentelemetry/backend/otel_setup.py
+++ b/rum/opentelemetry/backend/otel_setup.py
@@ -22,7 +22,9 @@ def setup_otel(service_name: str = "rum-music-agent", exporter_wrapper=None):
     host_l = host.lower()
     if host_l == "apps.dynatrace.com" or host_l.endswith(".apps.dynatrace.com"):
         dt_endpoint = dt_endpoint.replace(".apps.dynatrace.com", ".live.dynatrace.com")
-    otlp_base = f"{dt_endpoint}/api/v2/otlp"
+    # DT_ENDPOINT is expected to include the /api/v2/otlp base path; append it for
+    # backward compatibility if only the bare environment URL is provided.
+    otlp_base = dt_endpoint if dt_endpoint.endswith("/api/v2/otlp") else f"{dt_endpoint}/api/v2/otlp"
     headers = {"Authorization": f"Api-Token {dt_api_token}"}
 
     os.environ["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = "delta"


### PR DESCRIPTION
## What

Aligns the `rum/opentelemetry` demo so that `DT_ENDPOINT` holds the **full OTLP base URL** (`https://<env-id>.live.dynatrace.com/api/v2/otlp`), matching the convention already used by the other examples (`ai-coding-agents/claude-code`, `gemini-cli`, `langfuse`).

Previously this demo was the odd one out: `DT_ENDPOINT` was the bare environment URL and the code appended `/api/v2/otlp` internally. This confused reviewers (see docs PR review) and was inconsistent across the repo.

## Changes

- `backend/otel_setup.py` — use `DT_ENDPOINT` as the OTLP base directly. Kept a backward-compat fallback: if only the bare env URL is supplied, `/api/v2/otlp` is still appended, so existing `.env` files keep working.
- `.env_example` and `README.md` — updated the sample `DT_ENDPOINT` to include `/api/v2/otlp`.

## Why

Raised during review of the conversation-and-session-tracking docs page: the expected base URL is always `https://<env-id>.live.dynatrace.com/api/v2/otlp`, and the docs/other demos already reflect that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)