### PR TITLE
switch aws-bedrock openinference example to bindplane genainormalizer

### DIFF
--- a/aws-bedrock/openinference/Makefile
+++ b/aws-bedrock/openinference/Makefile
@@ -9,8 +9,11 @@ PORT             ?= 8000
 DT_ENDPOINT      ?= https://your-tenant.live.dynatrace.com
 DT_API_TOKEN     ?= dt0c01.*****
 
-override COLLECTOR_IMAGE     := ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:0.51.0
-override COLLECTOR_CONTAINER := otel-collector
+# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.104.0 tracks OTel
+# contrib v0.156.0 and bundles genainormalizerprocessor. Pinned so a version
+# bump surfaces normalization regressions in the e2e test.
+override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.104.0
+override COLLECTOR_CONTAINER := bindplane-otel-collector
 
 .PHONY: install run build push request stop logs help
 

--- a/aws-bedrock/openinference/README.md
+++ b/aws-bedrock/openinference/README.md
@@ -1,6 +1,21 @@
 # AWS Bedrock + OpenInference Demo
 
-Demonstrates tracing LangChain + AWS Bedrock API calls with Dynatrace via OpenInference instrumentation. Traces are sent to Dynatrace via OTLP.
+Demonstrates tracing LangChain + AWS Bedrock API calls with Dynatrace via OpenInference instrumentation. The app exports spans over OTLP to a local Bindplane collector, which normalizes them and forwards them to Dynatrace.
+
+## How it works
+
+OpenInference uses its own semantic conventions (`llm.model_name`, `llm.token_count.*`, etc.) that the Dynatrace AI Observability app does not natively understand. This example normalizes them to the Dynatrace `gen_ai.*` format in the collector, so no Dynatrace-side configuration is needed:
+
+```
+App  ->  Bindplane collector (genainormalizer + transform)  ->  Dynatrace Grail
+```
+
+The app knows only about `http://localhost:4318`; the collector is the component that authenticates with Dynatrace (`DT_ENDPOINT`, `DT_API_TOKEN`) and forwards spans. The pipeline runs two processors (see [`otelcol-config.yaml`](otelcol-config.yaml)):
+
+1. **`gen_ai_normalizer`** (source `openinference`, `remove_originals: true`) maps OpenInference attributes to `gen_ai.*` and reconstructs the flattened `llm.input_messages.N.*` / `llm.output_messages.N.*` attributes into `gen_ai.input.messages` and `gen_ai.output.messages` JSON. `remove_originals` drops the raw `llm.*` attributes so exported spans carry only `gen_ai.*` fields.
+2. **`transform/response_model`** mirrors `gen_ai.request.model` to `gen_ai.response.model`, which the AI Observability app requires and OpenInference has no separate field for.
+
+The collector is pinned to `ghcr.io/observiq/bindplane-agent:1.104.0` (Bindplane Distro for OpenTelemetry), which tracks OTel Collector contrib v0.156.0 and bundles the `genainormalizer` processor. The pin means a future version bump surfaces normalization changes in the e2e test.
 
 ## Prerequisites
 

--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -7,97 +7,27 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
-  # Replicates the OpenPipeline "openinference-ai-spans" pipeline using a
-  # standard OTel transform processor (OTTL statements).
-  #
-  # Scoped to OpenInference spans via:
-  #   (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-  #
-  # Processing order mirrors openpipeline-openinference.yaml processors 1–15.
-  # Note: later statements reference renamed attributes (e.g. gen_ai.request.model
-  # not llm.model_name) because OTTL statements execute sequentially.
-  transform/openinference:
+  # Normalize OpenInference attributes to the OTel gen_ai.* semantic conventions.
+  # The built-in "openinference" source maps model, provider, token usage, tool,
+  # agent and session attributes, and reconstructs the flattened
+  # llm.input_messages.N.* / llm.output_messages.N.* into gen_ai.input.messages
+  # and gen_ai.output.messages. remove_originals drops the raw llm.* attributes
+  # so the exported spans carry only gen_ai.* fields.
+  gen_ai_normalizer:
+    sources:
+      - name: openinference
+        remove_originals: true
+
+  # gen_ai_normalizer maps llm.model_name -> gen_ai.request.model but does not
+  # emit gen_ai.response.model (OpenInference has no separate response-model
+  # field). The Dynatrace AI Observability app requires gen_ai.response.model,
+  # so mirror the request model when the response has not set one.
+  transform/response_model:
+    error_mode: ignore
     trace_statements:
       - context: span
         statements:
-          # ── 1. OPERATION KIND ─────────────────────────────────────────────────
-          - set(attributes["gen_ai.operation.kind"], "task") where (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.operation.kind"], "workflow") where attributes["openinference.span.kind"] == "CHAIN" and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.operation.kind"], "tool") where attributes["openinference.span.kind"] == "TOOL" and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.operation.kind"], "agent") where attributes["openinference.span.kind"] == "AGENT" and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.operation.kind"], "retrieval") where attributes["openinference.span.kind"] == "RETRIEVER" and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 2. OPERATION NAME: LLM ────────────────────────────────────────────
-          - set(attributes["gen_ai.operation.name"], "chat") where (attributes["llm.token_count.total"] != nil or attributes["llm.model_name"] != nil) and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 3. LLM ATTRIBUTES: model + provider ──────────────────────────────
-          - set(attributes["gen_ai.request.model"], attributes["llm.model_name"]) where attributes["llm.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.model_name") where attributes["llm.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.provider.name"], attributes["llm.provider"]) where attributes["llm.provider"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.provider") where attributes["llm.provider"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 3b. FALLBACK: llm.system → gen_ai.provider.name ──────────────────
-          - set(attributes["gen_ai.provider.name"], attributes["llm.system"]) where attributes["llm.system"] != nil and attributes["gen_ai.provider.name"] == nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.system") where attributes["gen_ai.provider.name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 4. TOKEN USAGE ────────────────────────────────────────────────────
-          - set(attributes["gen_ai.usage.input_tokens"], attributes["llm.token_count.prompt"]) where attributes["llm.token_count.prompt"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.token_count.prompt") where attributes["llm.token_count.prompt"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.usage.output_tokens"], attributes["llm.token_count.completion"]) where attributes["llm.token_count.completion"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.token_count.completion") where attributes["llm.token_count.completion"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 4b. CACHE TOKEN USAGE ─────────────────────────────────────────────
-          - set(attributes["gen_ai.usage.prompt_caching.read_tokens"], attributes["llm.token_count.prompt_details.cache_read"]) where attributes["llm.token_count.prompt_details.cache_read"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.token_count.prompt_details.cache_read") where attributes["llm.token_count.prompt_details.cache_read"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.usage.prompt_caching.write_tokens"], attributes["llm.token_count.prompt_details.cache_write"]) where attributes["llm.token_count.prompt_details.cache_write"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.token_count.prompt_details.cache_write") where attributes["llm.token_count.prompt_details.cache_write"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 5. REQUEST PARAMETERS ─────────────────────────────────────────────
-          - set(attributes["gen_ai.request.temperature"], attributes["llm.temperature"]) where attributes["llm.temperature"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.temperature") where attributes["llm.temperature"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.request.max_tokens"], attributes["llm.max_tokens"]) where attributes["llm.max_tokens"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.max_tokens") where attributes["llm.max_tokens"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.request.top_p"], attributes["llm.top_p"]) where attributes["llm.top_p"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "llm.top_p") where attributes["llm.top_p"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 6. RESPONSE METADATA: finish reasons ──────────────────────────────
-          - set(attributes["gen_ai.response.finish_reasons"], [attributes["llm.finish_reason"]]) where attributes["llm.finish_reason"] != nil and (attributes["llm.token_count.total"] != nil or attributes["gen_ai.request.model"] != nil) and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 7. OPERATION NAME: EMBEDDINGS ──────────────────────────────────────
-          - set(attributes["gen_ai.operation.name"], "embeddings") where attributes["embedding.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 8. EMBEDDING ATTRIBUTES ────────────────────────────────────────────
-          - set(attributes["gen_ai.request.model"], attributes["embedding.model_name"]) where attributes["embedding.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "embedding.model_name") where attributes["embedding.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.embeddings.dimension.count"], attributes["embedding.vector_length"]) where attributes["embedding.vector_length"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "embedding.vector_length") where attributes["embedding.vector_length"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 9. RERANKER ─────────────────────────────────────────────────────────
-          - set(attributes["gen_ai.request.model"], attributes["reranker.model_name"]) where attributes["reranker.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "reranker.model_name") where attributes["reranker.model_name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 10. AGENT NAME ──────────────────────────────────────────────────────
-          - set(attributes["gen_ai.agent.name"], attributes["agent.name"]) where attributes["agent.name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "agent.name") where attributes["agent.name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 11. TOOL DETAILS ────────────────────────────────────────────────────
-          - set(attributes["gen_ai.tool.name"], attributes["tool.name"]) where attributes["tool.name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "tool.name") where attributes["tool.name"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.tool.description"], attributes["tool.description"]) where attributes["tool.description"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "tool.description") where attributes["tool.description"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 12. SOURCE METADATA ─────────────────────────────────────────────────
-          - set(attributes["ai.observability.source"], "openinference") where (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── 15. INPUT/OUTPUT FALLBACK (INTERIM) ─────────────────────────────────
-          - set(attributes["gen_ai.input.messages"], attributes["input.value"]) where attributes["input.value"] != nil and attributes["gen_ai.input.messages"] == nil and (attributes["llm.token_count.total"] != nil or attributes["gen_ai.request.model"] != nil) and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "input.value") where attributes["input.value"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.output.messages"], attributes["output.value"]) where attributes["output.value"] != nil and (attributes["llm.token_count.total"] != nil or attributes["gen_ai.request.model"] != nil) and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - delete_key(attributes, "output.value") where attributes["output.value"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-
-          # ── FIXUPS ──────────────────────────────────────────────────────────────
-          - set(attributes["gen_ai.system"], "azure.ai.openai") where attributes["gen_ai.provider.name"] == "azure" and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
-          - set(attributes["gen_ai.response.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil and (IsMatch(instrumentation_scope.name, "openinference.*") or IsMatch(attributes["otel.scope.name"], "openinference.*"))
+          - set(attributes["gen_ai.response.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil and attributes["gen_ai.response.model"] == nil
 
   batch:
     send_batch_size: 512
@@ -113,7 +43,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [transform/openinference, batch]
+      processors: [gen_ai_normalizer, transform/response_model, batch]
       exporters: [otlp_http/dynatrace]
     metrics:
       receivers: [otlp]


### PR DESCRIPTION
Migrates the `aws-bedrock/openinference` example from the Dynatrace OTel collector (hand-written OTTL normalization) to the Bindplane distro collector with the built-in `genainormalizer` processor, mirroring the `openai/openinference` example (AI-306).

## Changes
- **otelcol-config.yaml**: replaced the ~80-line OTTL `transform/openinference` block with `gen_ai_normalizer` (source `openinference`, `remove_originals: true`) + `transform/response_model` (mirrors `gen_ai.request.model` → `gen_ai.response.model`, which the normalizer omits and the AI Observability app requires). Dropped the abandoned `gen_ai.operation.kind`. Kept the grpc+http receivers and metrics/logs pipelines.
- **Makefile**: collector image → `ghcr.io/observiq/bindplane-agent:1.104.0` (BDOT, bundles genainormalizer v0.156.0); container → `bindplane-otel-collector`.

## Notes
- Renovate tracking for the Bindplane image is added in #156 — that PR should merge first (or this coverage lands with it).
- e2e (`TestAWSBedrockOpenInference`) unchanged; it has no distro- or `operation.kind`-specific assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)