### PR TITLE
Sync README demo tables with directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,11 @@ Monitor AI agent frameworks with Dynatrace.
 | Framework | OneAgent | OpenInference | OpenTelemetry |
 |-----------|----------|---------------|---------------|
 | [AWS Bedrock Agents](./aws-bedrock-agents/) | [✓](./aws-bedrock-agents/oneagent/) | — | — |
-| [AWS Strands Agents](./aws-strands/oneagent/) | [✓](./aws-strands/oneagent/) | — | — |
+| [AWS Strands Agents](./aws-strands/oneagent/) | [✓](./aws-strands/oneagent/) | — | [✓](./aws-strands/opentelemetry/) |
 | [CrewAI](./crewai/opentelemetry/) | — | — | [✓](./crewai/opentelemetry/) |
 | [Google ADK](./google-adk/opentelemetry/) | — | — | [✓](./google-adk/opentelemetry/) |
 | [Haystack](./haystack/oneagent/) | [✓](./haystack/oneagent/) | — | — |
+| [Langfuse](./langfuse/) | — | — | [✓ Python](./langfuse/opentelemetry/) / [✓ Node](./langfuse/opentelemetry-node/) |
 | [LangGraph](./langgraph/) | [✓](./langgraph/oneagent/) | — | [✓](./langgraph/opentelemetry/) |
 | [LiteLLM](./litellm/opentelemetry/) | — | — | [✓](./litellm/opentelemetry/) |
 | [MCP (Model Context Protocol)](mcp/opentelemetry/) | — | — | [✓](mcp/opentelemetry/) |


### PR DESCRIPTION
Aligns the README demo tables with the actual repository layout.

## Changes
- **AWS Strands Agents** — added the missing OpenTelemetry link (`aws-strands/opentelemetry/` existed but wasn't linked)
- **Langfuse** — added a new Agent Framework Demos row (Python + Node OpenTelemetry variants) that was entirely absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)