### PR TITLE
added temperature, conversion id and system instruction span attributes

### DIFF
--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -41,18 +41,19 @@ if __name__ == "__main__":
             base_url=os.getenv("OPENAI_API_BASE"),
             api_key=os.getenv("OPENAI_API_KEY"),
         )
-    otel_trace.get_current_span().set_attribute("gen_ai.conversation.id", str(uuid.uuid4()))
-    response: Stream[ChatCompletionChunk] = client.chat.completions.create(  # type: ignore[assignment]
-        model=MODEL,
-        messages=[
-            {"role": "system", "content": "You are a haiku poet."},
-            {"role": "user", "content": "Write a haiku."},
-        ],
-        max_completion_tokens=2000,
-        temperature=1.0,
-        stream=True,
-        stream_options={"include_usage": True},
-    )
-    for chunk in response:
-        if chunk.choices and (content := chunk.choices[0].delta.content):
-            print(content, end="")
+    tracer = otel_trace.get_tracer(__name__)
+    with tracer.start_as_current_span("haiku") as span:
+        span.set_attribute("gen_ai.conversation.id", str(uuid.uuid4()))
+        response: Stream[ChatCompletionChunk] = client.chat.completions.create(  # type: ignore[assignment]
+            model=MODEL,
+            messages=[
+                {"role": "user", "content": "Write a haiku."},
+            ],
+            max_completion_tokens=2000,
+            temperature=1.0,
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+        for chunk in response:
+            if chunk.choices and (content := chunk.choices[0].delta.content):
+                print(content, end="")

--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -20,7 +20,7 @@ MODEL: str = os.environ.get("MODEL", "gpt-4o")
 #                         OTEL_EXPORTER_OTLP_HEADERS=Authorization=Api-Token <token>
 detectors = [OTELResourceDetector(), ProcessResourceDetector(), OsResourceDetector()]
 resource = get_aggregated_resources(detectors=detectors, initial_resource=Resource.create(
-    {service_attributes.SERVICE_NAME: "openai/openinference"}))
+    {service_attributes.SERVICE_NAME: "openinference"}))
 
 tracer_provider = trace_sdk.TracerProvider(resource=resource)
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))

--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -1,8 +1,10 @@
 import os
+import uuid
 import openai
 from openai import Stream
 from openai.types.chat import ChatCompletionChunk
 from openinference.instrumentation.openai import OpenAIInstrumentor
+from opentelemetry import trace as otel_trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
@@ -18,7 +20,7 @@ MODEL: str = os.environ.get("MODEL", "gpt-4o")
 #                         OTEL_EXPORTER_OTLP_HEADERS=Authorization=Api-Token <token>
 detectors = [OTELResourceDetector(), ProcessResourceDetector(), OsResourceDetector()]
 resource = get_aggregated_resources(detectors=detectors, initial_resource=Resource.create(
-    {service_attributes.SERVICE_NAME: "openinference"}))
+    {service_attributes.SERVICE_NAME: "openai/openinference"}))
 
 tracer_provider = trace_sdk.TracerProvider(resource=resource)
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
@@ -39,10 +41,15 @@ if __name__ == "__main__":
             base_url=os.getenv("OPENAI_API_BASE"),
             api_key=os.getenv("OPENAI_API_KEY"),
         )
+    otel_trace.get_current_span().set_attribute("gen_ai.conversation.id", str(uuid.uuid4()))
     response: Stream[ChatCompletionChunk] = client.chat.completions.create(  # type: ignore[assignment]
         model=MODEL,
-        messages=[{"role": "user", "content": "Write a haiku."}],
+        messages=[
+            {"role": "system", "content": "You are a haiku poet."},
+            {"role": "user", "content": "Write a haiku."},
+        ],
         max_completion_tokens=2000,
+        temperature=1.0,
         stream=True,
         stream_options={"include_usage": True},
     )

--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -4,7 +4,7 @@ import openai
 from openai import Stream
 from openai.types.chat import ChatCompletionChunk
 from openinference.instrumentation.openai import OpenAIInstrumentor
-from opentelemetry import trace as otel_trace
+from openinference.instrumentation import using_attributes
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
@@ -41,16 +41,14 @@ if __name__ == "__main__":
             base_url=os.getenv("OPENAI_API_BASE"),
             api_key=os.getenv("OPENAI_API_KEY"),
         )
-    tracer = otel_trace.get_tracer(__name__)
-    with tracer.start_as_current_span("haiku") as span:
-        span.set_attribute("gen_ai.conversation.id", str(uuid.uuid4()))
+    with using_attributes(session_id=str(uuid.uuid4())):
         response: Stream[ChatCompletionChunk] = client.chat.completions.create(  # type: ignore[assignment]
             model=MODEL,
             messages=[
+                {"role": "system", "content": "You are a haiku poet."},
                 {"role": "user", "content": "Write a haiku."},
             ],
             max_completion_tokens=2000,
-            temperature=1.0,
             stream=True,
             stream_options={"include_usage": True},
         )

--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
             max_completion_tokens=2000,
             stream=True,
             stream_options={"include_usage": True},
+            temperature=1.0,
         )
         for chunk in response:
             if chunk.choices and (content := chunk.choices[0].delta.content):

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -16,6 +16,14 @@ processors:
       - name: openinference
         remove_originals: true
 
+  # reads ll.m* attributes before gen_ai normalizer deletes them
+  transform/pre_normalize:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["gen_ai.system_instructions"], attributes["llm.input_messages.0.message.content"]) where attributes["llm.input_messages.0.message.role"] == "system"
+
   # gen_ai_normalizer maps llm.model_name -> gen_ai.request.model but does not
   # emit gen_ai.response.model (OpenInference has no separate response-model
   # field). The Dynatrace AI Observability app requires gen_ai.response.model,
@@ -112,7 +120,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [gen_ai_normalizer, transform/response_model]
+      processors: [transform/pre_normalize, gen_ai_normalizer, transform/response_model]
       exporters: [debug, otlp_http/dynatrace]
     # Second branch of the same spans: normalize, keep only LLM spans, and feed
     # the metric connectors. Kept separate from the export pipeline so the filter

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -36,7 +36,6 @@ processors:
       - context: span
         statements:
           - set(attributes["gen_ai.response.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil and attributes["gen_ai.response.model"] == nil
-          - set(attributes["gen_ai.request.temperature"], attributes["llm.temperature"]) where attributes["llm.temperature"] != nil
 
   # Keep only spans that represent an LLM call (gen_ai.request.model is set by the
   # normalizer on LLM spans). Feeds the metrics connectors so the derived metrics
@@ -129,7 +128,7 @@ service:
     # here never drops spans from Distributed Tracing.
     traces/genai_metrics:
       receivers: [otlp]
-      processors: [gen_ai_normalizer, transform/response_model, filter/genai_only]
+      processors: [transform/pre_normalize, gen_ai_normalizer, transform/response_model, filter/genai_only]
       exporters: [spanmetrics, signal_to_metrics]
     metrics:
       receivers: [spanmetrics, signal_to_metrics]

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -26,6 +26,7 @@ processors:
       - context: span
         statements:
           - set(attributes["gen_ai.response.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil and attributes["gen_ai.response.model"] == nil
+          - set(attributes["gen_ai.request.temperature"], attributes["llm.temperature"]) where attributes["llm.temperature"] != nil
 
   # Keep only spans that represent an LLM call (gen_ai.request.model is set by the
   # normalizer on LLM spans). Feeds the metrics connectors so the derived metrics

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -16,13 +16,15 @@ processors:
       - name: openinference
         remove_originals: true
 
-  # reads ll.m* attributes before gen_ai normalizer deletes them
+  # Reads llm.* attributes before gen_ai_normalizer deletes them 
   transform/pre_normalize:
     error_mode: ignore
     trace_statements:
       - context: span
         statements:
-          - set(attributes["gen_ai.system_instructions"], attributes["llm.input_messages.0.message.content"]) where attributes["llm.input_messages.0.message.role"] == "system"
+          - set(attributes["temp.invocation_params"], ParseJSON(attributes["llm.invocation_parameters"])) where attributes["llm.invocation_parameters"] != nil
+          - set(attributes["gen_ai.request.temperature"], attributes["temp.invocation_params"]["temperature"]) where attributes["temp.invocation_params"]["temperature"] != nil
+          - delete_key(attributes, "temp.invocation_params") where attributes["temp.invocation_params"] != nil
 
   # gen_ai_normalizer maps llm.model_name -> gen_ai.request.model but does not
   # emit gen_ai.response.model (OpenInference has no separate response-model

--- a/test/e2e/openai_openinference_test.go
+++ b/test/e2e/openai_openinference_test.go
@@ -16,5 +16,5 @@ func TestOpenAIOpenInference(t *testing.T) {
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
 | limit 1`,
-		"pydantic-ai-music-agent", genAIClientMetrics)
+		"openai/openinference", genAIClientMetrics)
 }


### PR DESCRIPTION
Adds two optional gen_ai.* span attributes and metrics to the openai/openinference demo, improving dashboard coverage in the Dynatrace AI Observability app.

**Changes**

- gen_ai.request.temperature — extracted from llm.invocation_parameters JSON via ParseJSON in a transform/pre_normalize collector processor
- gen_ai.conversation.id — set via using_attributes(session_id=...)
- gen_ai.client.token.usage — derived from gen_ai.usage.input_tokens / gen_ai.usage.output_tokens span attributes via the signal_to_metrics connector
- gen_ai.system_instructions — omitted for now; extracting it from llm.input_messages causes the system prompt to appear twice in the dashboard (once in gen_ai.system_instructions, once in gen_ai.input.messages from the normalizer)