### PR TITLE
Add sticky PR comment for e2e span audit reports

### DIFF
--- a/.github/scripts/pr-audit-comment.sh
+++ b/.github/scripts/pr-audit-comment.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
-# Post (or update) a sticky PR comment summarizing the span-audit reports produced
-# by the e2e suites that ran for this pull request.
+# Build the body of the sticky PR comment summarizing the span-audit reports
+# produced by the e2e suites that ran for this pull request. The stickiness
+# (find/create/update a single comment) is handled by the
+# marocchino/sticky-pull-request-comment action; this script only writes the
+# comment body to OUTPUT_FILE.
 #
 # Behavior:
 #   0 reports          → short "no suites affected" note
@@ -8,20 +11,15 @@
 #   > THRESHOLD         → each report collapsed in a <details> fold with a verdict
 #                         tick in the summary, plus a link to the run for the detail.
 #
-# The comment is made sticky via a hidden HTML marker: on every push we find the
-# existing comment carrying the marker and PATCH it, otherwise we POST a new one.
-#
 # Inputs (environment variables):
-#   GH_TOKEN    - token with pull-requests:write (provided by the workflow)
-#   REPO        - owner/repo (github.repository)
-#   PR_NUMBER   - pull request number (github.event.pull_request.number)
 #   RUN_URL     - URL of this Actions run (linked in the overflow case)
 #   REPORTS_DIR - directory containing the merged *.md / *.json reports
+#   OUTPUT_FILE - path to write the comment body to (default: comment.md)
 set -euo pipefail
 
 THRESHOLD=2
-MARKER="<!-- e2e-span-audit-report -->"
 REPORTS_DIR="${REPORTS_DIR:-all-reports}"
+OUTPUT_FILE="${OUTPUT_FILE:-comment.md}"
 
 # Collect report basenames (one per suite) from the JSON files, sorted for a
 # stable comment order. JSON is the source of truth for the verdict tick; the
@@ -32,9 +30,9 @@ while IFS= read -r f; do
 done < <(find "$REPORTS_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | sort)
 count=${#json_files[@]}
 
-body_file="$(mktemp)"
+body_file="$OUTPUT_FILE"
+: > "$body_file"
 {
-  echo "$MARKER"
   echo "## 🔭 GenAI span audit"
   echo
 } > "$body_file"
@@ -96,17 +94,4 @@ else
   done
 fi
 
-# Upsert the sticky comment: find an existing comment carrying the marker,
-# PATCH it if present, otherwise POST a new one.
-existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-  --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n1 || true)
-
-if [ -n "$existing_id" ]; then
-  jq -n --rawfile body "$body_file" '{body: $body}' \
-    | gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" --input -
-  echo "updated comment ${existing_id}"
-else
-  jq -n --rawfile body "$body_file" '{body: $body}' \
-    | gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input -
-  echo "created new comment"
-fi
+echo "wrote comment body to ${body_file} (${count} reports)"

--- a/.github/scripts/pr-audit-comment.sh
+++ b/.github/scripts/pr-audit-comment.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Post (or update) a sticky PR comment summarizing the span-audit reports produced
+# by the e2e suites that ran for this pull request.
+#
+# Behavior:
+#   0 reports          → short "no suites affected" note
+#   1..THRESHOLD        → full report tables inline
+#   > THRESHOLD         → each report collapsed in a <details> fold with a verdict
+#                         tick in the summary, plus a link to the run for the detail.
+#
+# The comment is made sticky via a hidden HTML marker: on every push we find the
+# existing comment carrying the marker and PATCH it, otherwise we POST a new one.
+#
+# Inputs (environment variables):
+#   GH_TOKEN    - token with pull-requests:write (provided by the workflow)
+#   REPO        - owner/repo (github.repository)
+#   PR_NUMBER   - pull request number (github.event.pull_request.number)
+#   RUN_URL     - URL of this Actions run (linked in the overflow case)
+#   REPORTS_DIR - directory containing the merged *.md / *.json reports
+set -euo pipefail
+
+THRESHOLD=2
+MARKER="<!-- e2e-span-audit-report -->"
+REPORTS_DIR="${REPORTS_DIR:-all-reports}"
+
+# Collect report basenames (one per suite) from the JSON files, sorted for a
+# stable comment order. JSON is the source of truth for the verdict tick; the
+# matching .md holds the human-readable tables.
+json_files=()
+while IFS= read -r f; do
+  [ -n "$f" ] && json_files+=("$f")
+done < <(find "$REPORTS_DIR" -maxdepth 1 -name '*.json' 2>/dev/null | sort)
+count=${#json_files[@]}
+
+body_file="$(mktemp)"
+{
+  echo "$MARKER"
+  echo "## 🔭 GenAI span audit"
+  echo
+} > "$body_file"
+
+verdict_tick() {
+  case "$1" in
+    FULL) printf '🌟' ;;
+    PASS) printf '✅' ;;
+    FAIL) printf '❌' ;;
+    *)    printf '⚪' ;;
+  esac
+}
+
+if [ "$count" -eq 0 ]; then
+  {
+    echo "No e2e suites were affected by this PR, so no span-audit reports were generated."
+    echo
+    echo "_(Suites run only when their demo directory, test file, or shared e2e infrastructure changes.)_"
+  } >> "$body_file"
+
+elif [ "$count" -le "$THRESHOLD" ]; then
+  # Few suites: inline the full report tables.
+  for jf in "${json_files[@]}"; do
+    md="${jf%.json}.md"
+    if [ -f "$md" ]; then
+      cat "$md" >> "$body_file"
+      echo >> "$body_file"
+      echo "---" >> "$body_file"
+      echo >> "$body_file"
+    fi
+  done
+  echo "[View full run details](${RUN_URL})" >> "$body_file"
+
+else
+  # Many suites: collapse each report, with a verdict tick in the summary line.
+  {
+    echo "${count} suites ran. [View full run details](${RUN_URL})"
+    echo
+  } >> "$body_file"
+  for jf in "${json_files[@]}"; do
+    md="${jf%.json}.md"
+    sdk=$(jq -r '.sdk // "?"' "$jf")
+    instr=$(jq -r '.instrumentation // "?"' "$jf")
+    verdict=$(jq -r '.verdict // "?"' "$jf")
+    tick=$(verdict_tick "$verdict")
+    {
+      echo "<details>"
+      echo "<summary>${tick} <strong>${sdk} / ${instr}</strong> — ${verdict}</summary>"
+      echo
+      if [ -f "$md" ]; then
+        cat "$md"
+      else
+        echo "_report markdown not found_"
+      fi
+      echo
+      echo "</details>"
+      echo
+    } >> "$body_file"
+  done
+fi
+
+# Upsert the sticky comment: find an existing comment carrying the marker,
+# PATCH it if present, otherwise POST a new one.
+existing_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+  --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -n1 || true)
+
+if [ -n "$existing_id" ]; then
+  jq -n --rawfile body "$body_file" '{body: $body}' \
+    | gh api -X PATCH "repos/${REPO}/issues/comments/${existing_id}" --input -
+  echo "updated comment ${existing_id}"
+else
+  jq -n --rawfile body "$body_file" '{body: $body}' \
+    | gh api -X POST "repos/${REPO}/issues/${PR_NUMBER}/comments" --input -
+  echo "created new comment"
+fi

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -517,14 +517,18 @@ jobs:
           path: all-reports/
         continue-on-error: true
 
-      - name: Post or update PR comment
+      - name: Build comment body
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPORTS_DIR: all-reports
+          OUTPUT_FILE: comment.md
         run: bash .github/scripts/pr-audit-comment.sh
+
+      - name: Post or update PR comment
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
+        with:
+          header: e2e-span-audit
+          path: comment.md
 
   notify:
     name: Notify on regression or recovery

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -493,6 +493,39 @@ jobs:
           path: test/e2e/reports/
           retention-days: 30
 
+  # Posts (or updates) a single sticky PR comment summarizing the span-audit
+  # reports from every suite that ran for this PR. Runs only on pull_request.
+  # ≤2 suites → full tables inline; >2 → collapsed per-suite folds + run link.
+  pr-audit-comment:
+    name: Comment span audit on PR
+    needs: [oneagent, otelcol]
+    # Skip fork PRs: they get a read-only GITHUB_TOKEN and cannot write comments.
+    if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Download all audit report artifacts
+        # merge-multiple flattens every span-audit-reports-* artifact into one dir.
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: span-audit-reports-*
+          merge-multiple: true
+          path: all-reports/
+        continue-on-error: true
+
+      - name: Post or update PR comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REPORTS_DIR: all-reports
+        run: bash .github/scripts/pr-audit-comment.sh
+
   notify:
     name: Notify on regression or recovery
     needs: [oneagent-nightly, otelcol]


### PR DESCRIPTION
## What

Adds a sticky PR comment summarizing the GenAI span-audit reports produced by the e2e suites that run for a PR — so results are visible on the PR itself, not only in per-job step summaries and artifacts.

## Behavior

- **≤2 suites** → full report tables inline, plus a link to the run.
- **>2 suites** → intro + run link, then each suite collapsed in a `<details>` fold with a verdict tick in the summary (🌟 FULL / ✅ PASS / ❌ FAIL / ⚪ unknown); full table expands on click.
- **0 suites** (path-filtered PR touched no demo/test/infra) → short note.
- The comment is **sticky**: a hidden marker lets each push update the same comment instead of adding new ones.

## How

- New `.github/scripts/pr-audit-comment.sh`: builds the body from the merged `all-reports/` (JSON drives the verdict tick, `.md` holds the tables) and upserts via `gh api` (PATCH if the marker comment exists, else POST). Dependency-free, matching the `notify-nightly.sh` style.
- New `pr-audit-comment` job in `e2e.yml`: `needs: [oneagent, otelcol]`, `if: always() && pull_request`, `pull-requests: write`, downloads all `span-audit-reports-*` artifacts (`merge-multiple`), runs the script.
- **Fork PRs are skipped** (`head.repo.fork == false`) since they receive a read-only `GITHUB_TOKEN` and cannot write comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)