### PR TITLE
fix langfuse openpipeline duration metric unit (microseconds -> seconds)

### DIFF
--- a/langfuse/opentelemetry/openpipeline-langfuse.yaml
+++ b/langfuse/opentelemetry/openpipeline-langfuse.yaml
@@ -225,6 +225,23 @@ processing:
         script: |
           fieldsAdd `ai.observability.source` = "langfuse"
 
+    # ============================================================================
+    # 14. DURATION IN SECONDS (feeds the operation-duration metric below)
+    # ============================================================================
+    # The span `duration` field is in nanoseconds. The metric-extraction
+    # "duration" measurement emits MICROSECONDS, but the OTel semconv metric
+    # gen_ai.client.operation.duration (and every native SDK emitter) is in
+    # SECONDS. Materialize a seconds value here and point the metric at it via
+    # measurement: "field" so the OpenPipeline path matches the Collector path.
+    - id: "langfuse-duration-seconds"
+      enabled: true
+      matcher: 'langfuse.observation.type == "generation"'
+      type: "dql"
+      description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
+      dql:
+        script: |
+          fieldsAdd duration_seconds = toDouble(duration) / 1000000000.0
+
 # ==============================================================================
 # METRIC EXTRACTION
 # ==============================================================================
@@ -245,8 +262,11 @@ metricExtraction:
       description: "Extract gen_ai.client.operation.duration from generation span duration"
       samplingAwareHistogramMetric:
         metricKey: "gen_ai.client.operation.duration"
-        measurement: "duration"
-        # Required by the schema when measurement is "duration".
+        # Measure the seconds field computed in processing (step 14). The built-in
+        # "duration" measurement would emit microseconds, which the app charts as
+        # if seconds — off by 1,000,000.
+        measurement: "field"
+        field: "duration_seconds"
         aggregation: "enabled"
         sampling: "enabled"
         dimensions:


### PR DESCRIPTION
## Summary

Fixes the `gen_ai.client.operation.duration` metric unit for the **langfuse OpenPipeline** path. The metric-extraction "duration" measurement emits **microseconds**, but the OTel semconv metric — and every native SDK emitter (and the langfuse Collector `spanmetrics` path) — is in **seconds**. As a result the `langfuse-openpipeline` service reported ~1.5M instead of ~1.5 s, breaking the app's latency charts for that service (off by 1,000,000).

## Change

`langfuse/opentelemetry/openpipeline-langfuse.yaml`:
- Add a processing step `langfuse-duration-seconds` computing `duration_seconds = toDouble(duration) / 1e9` (span `duration` is nanoseconds).
- Switch the metric processor from `measurement: "duration"` to `measurement: "field"` / `field: "duration_seconds"`, preserving the metric key, dimensions, sampling, and aggregation.

## Verification

Deployed the equivalent change to the `ixq6468h` tenant's `Langfuse AI Observability - Spans` pipeline and confirmed the pipeline now uses `measurement: field` / `field: duration_seconds` with all dimensions preserved. New `langfuse-openpipeline` spans should report the metric in seconds (~1.5), matching `langfuse` / `langfuse-node`. (Existing datapoints stay at the old µs value; a fresh demo run is needed to see the corrected numbers.)

Split out from #164 as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)