### PR TITLE
Run e2e on fork PRs via pull_request_target behind maintainer approval

### DIFF
--- a/.github/scripts/compute-e2e-matrix.sh
+++ b/.github/scripts/compute-e2e-matrix.sh
@@ -2,9 +2,10 @@
 # Outputs oneagent-matrix and otelcol-matrix JSON arrays to GITHUB_OUTPUT.
 #
 # Inputs (environment variables):
-#   EVENT       - github.event_name (pull_request | workflow_dispatch | schedule)
+#   EVENT       - github.event_name (pull_request | pull_request_target | workflow_dispatch | schedule)
 #   SUITE_INPUT - optional suite name from workflow_dispatch input
-#   BASE_REF    - PR base branch (e.g. "main"), set only for pull_request events
+#   BASE_REF    - PR base branch (e.g. "main"), set only for PR events
+#   HEAD_SHA    - PR head commit SHA, set only for PR events; diffed as data (never executed)
 set -euo pipefail
 
 OA_ALL='[
@@ -41,10 +42,20 @@ OC_ALL='[
   {"name":"rum-opentelemetry","app_dir":"rum/opentelemetry","test_file":"test/e2e/rum_sessionid_agentic_test.go","test_run":"TestRUMOpenTelemetry","otel_service_name":"rum/opentelemetry","needs_playwright":true}
 ]'
 
-if [[ "$EVENT" == "pull_request" ]]; then
-  # Fetch the tip of the base branch so we can diff against it.
+if [[ "$EVENT" == "pull_request" || "$EVENT" == "pull_request_target" ]]; then
+  # Fetch the base branch tip and the PR head so we can diff between them. On
+  # pull_request_target the working tree is the base (trusted), so HEAD is not the PR head;
+  # we diff against the explicitly-fetched HEAD_SHA instead. git diff compares the two commit
+  # trees directly and needs no common ancestor, so shallow fetches are fine.
   git fetch --depth=1 origin "$BASE_REF"
-  CHANGED=$(git diff --name-only FETCH_HEAD HEAD)
+  BASE_SHA=$(git rev-parse FETCH_HEAD)
+  if [[ -n "${HEAD_SHA:-}" ]]; then
+    git fetch --depth=1 origin "$HEAD_SHA"
+    HEAD_REV=$(git rev-parse FETCH_HEAD)
+  else
+    HEAD_REV=HEAD
+  fi
+  CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_REV")
   CHANGED_JSON=$(echo "$CHANGED" | jq -Rs 'split("\n") | map(select(length > 0))')
 
   # Changes to shared infrastructure trigger a full run:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,7 +9,13 @@ on:
         description: 'Run only this suite by name (e.g. openai-oneagent, litellm-opentelemetry). Leave blank to run all.'
         required: false
         type: string
+  # Same-repo PRs: secrets are available automatically, e2e runs without approval.
   pull_request:
+  # Fork PRs: 'pull_request' withholds secrets, so those runs would panic. Fork PRs
+  # instead run via 'pull_request_target' (base context, secrets available) gated by the
+  # 'e2e-fork' Environment's required reviewers — a maintainer must approve each run in the
+  # PR pipeline before untrusted fork code executes with secrets. See the fork jobs below.
+  pull_request_target:
 
 permissions:
   contents: read
@@ -21,10 +27,19 @@ jobs:
   #   pull_request       → all entries (full validation on every PR)
   filter:
     runs-on: ubuntu-latest
+    # Route each PR through exactly one event: same-repo via pull_request, forks via
+    # pull_request_target. Prevents the duplicate workflow run that dual triggers would
+    # otherwise create on same-repo PRs.
+    if: >-
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+      && (github.event_name != 'pull_request_target' || github.event.pull_request.head.repo.fork == true)
     outputs:
       oneagent-matrix: ${{ steps.compute.outputs.oneagent-matrix }}
       otelcol-matrix: ${{ steps.compute.outputs.otelcol-matrix }}
     steps:
+      # Checks out the base ref (trusted) on pull_request_target — the fork's code is NOT
+      # executed here. compute-e2e-matrix.sh diffs against HEAD_SHA as data only; the matrix
+      # values themselves come from the hardcoded lists in the trusted base script.
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
@@ -34,6 +49,7 @@ jobs:
           EVENT: ${{ github.event_name }}
           SUITE_INPUT: ${{ inputs.suite }}
           BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: bash .github/scripts/compute-e2e-matrix.sh
 
   # Per-suite oneagent job for PR and workflow_dispatch triggers.
@@ -42,7 +58,18 @@ jobs:
   oneagent:
     name: E2E / ${{ matrix.name }}
     needs: filter
-    if: (github.event_name == 'pull_request' || inputs.suite != '') && needs.filter.outputs.oneagent-matrix != '[]'
+    # Same-repo PRs run on pull_request (secrets available, no approval). Fork PRs run on
+    # pull_request_target, gated below by the e2e-fork Environment's required reviewers.
+    if: >-
+      needs.filter.outputs.oneagent-matrix != '[]'
+      && (
+        (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+        || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true)
+        || (github.event_name == 'workflow_dispatch' && inputs.suite != '')
+      )
+    # On pull_request_target the job waits for a required reviewer to approve the e2e-fork
+    # Environment before it starts, and only then can it read the secrets. No-op for other events.
+    environment: ${{ github.event_name == 'pull_request_target' && 'e2e-fork' || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -50,8 +77,12 @@ jobs:
         include: ${{ fromJson(needs.filter.outputs.oneagent-matrix) }}
 
     steps:
+      # Explicitly check out the PR head. On pull_request_target this is the fork's code,
+      # which only runs after a maintainer approved the e2e-fork Environment above.
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
@@ -405,7 +436,17 @@ jobs:
   otelcol:
     name: E2E / ${{ matrix.name }}
     needs: filter
-    if: needs.filter.outputs.otelcol-matrix != '[]'
+    # Same-repo PRs run on pull_request; fork PRs on pull_request_target behind the e2e-fork
+    # Environment's required reviewers. Also runs on schedule/workflow_dispatch (nightly + manual).
+    if: >-
+      needs.filter.outputs.otelcol-matrix != '[]'
+      && (
+        github.event_name == 'schedule'
+        || github.event_name == 'workflow_dispatch'
+        || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
+        || (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.fork == true)
+      )
+    environment: ${{ github.event_name == 'pull_request_target' && 'e2e-fork' || '' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -413,8 +454,12 @@ jobs:
         include: ${{ fromJson(needs.filter.outputs.otelcol-matrix) }}
 
     steps:
+      # Explicitly check out the PR head. On pull_request_target this is the fork's code,
+      # which only runs after a maintainer approved the e2e-fork Environment above.
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0


### PR DESCRIPTION
## Problem

E2E jobs on fork PRs (e.g. #165) fail immediately with `panic: required env var not set: DT_APPS_ENDPOINT`. GitHub withholds repository secrets from `pull_request` runs originating from forks, so every `secrets.*` resolves empty and the Go suite panics. This hits every fork PR.

## Change

Route fork PRs through **`pull_request_target`** (runs in the base-repo context, so secrets are available) gated by a GitHub **Environment with required reviewers** — the maintainer-approval-in-the-PR-pipeline pattern used by e.g. opentelemetry-collector-contrib.

- **Same-repo PRs** → keep running on `pull_request`, secrets available automatically, **no approval** needed.
- **Fork PRs** → run on `pull_request_target`, and the `oneagent`/`otelcol` jobs reference `environment: e2e-fork`. The job **pauses until a required reviewer approves** it; only then does it get the secrets and execute the fork code.
- Fork jobs check out the PR head SHA explicitly (`pull_request_target` defaults to base).
- The `filter` job runs the **trusted base** copy of `compute-e2e-matrix.sh` and diffs the head SHA as *data only* — matrix values come from the hardcoded lists in the base script, so a fork can't inject matrix content. Dual triggers are de-duped via job `if` so same-repo PRs don't get a second (skipped) run.

## ⚠️ Required one-time repo setup

Create an Environment named **`e2e-fork`** under **Settings → Environments** with **required reviewers** (the maintainers who should approve fork e2e runs). Without it there is no approval gate and the pattern's safety guarantee doesn't hold. Environment-scoped secrets can also live there instead of repo-wide if you want tighter scoping.

## Security note

`pull_request_target` + checking out fork code + secrets means untrusted code runs with credentials **after approval**. The required-reviewer gate is the mitigation: approve only after reviewing the fork diff. Workflow logic itself always comes from the base branch, so a PR can't alter the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)