### PR TITLE
Backfill gen_ai.client.token.usage and operation.duration for OneAgent via OpenPipeline

### DIFF
--- a/anthropic/oneagent/README.md
+++ b/anthropic/oneagent/README.md
@@ -39,3 +39,7 @@ Demonstrates tracing Anthropic Bedrock SDK API calls with Dynatrace via OneAgent
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/aws-bedrock-agents/oneagent/README.md
+++ b/aws-bedrock-agents/oneagent/README.md
@@ -50,3 +50,7 @@ Bedrock AgentCore comes with [Observability](https://docs.aws.amazon.com/bedrock
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape topology.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/aws-bedrock/oneagent/README.md
+++ b/aws-bedrock/oneagent/README.md
@@ -39,3 +39,7 @@ Demonstrates tracing LangChain + AWS Bedrock API calls with Dynatrace via OneAge
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/aws-strands/oneagent/README.md
+++ b/aws-strands/oneagent/README.md
@@ -42,3 +42,7 @@ The app exposes a FastAPI HTTP server. A POST to `/agent` creates a Strands `Age
 | `make push` | Build and push image to registry |
 | `make request` | POST /agent to localhost:8000 |
 | `make help` | Show all available targets |
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/cohere/oneagent/README.md
+++ b/cohere/oneagent/README.md
@@ -40,3 +40,7 @@ Demonstrates tracing Cohere SDK API calls with Dynatrace via OneAgent auto-instr
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/groq/oneagent/README.md
+++ b/groq/oneagent/README.md
@@ -39,3 +39,7 @@ Demonstrates tracing Groq SDK API calls with Dynatrace via OneAgent auto-instrum
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/haystack/oneagent/README.md
+++ b/haystack/oneagent/README.md
@@ -48,3 +48,7 @@ Press `Ctrl+K` in Dynatrace and search for **AI Observability** to explore the t
 ![AI Observability — Explorer showing haystack/oneagent service](assets/explorer.png)
 
 ![AI Observability — Prompts detail with agentic trace and captured prompt/completion](assets/prompt.png)
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/langgraph/oneagent/README.md
+++ b/langgraph/oneagent/README.md
@@ -9,7 +9,7 @@ For a collector-based variant (which exports via OTLP and can redact secrets bef
 - Runs a FastAPI server exposing `POST /haiku` (accepts a `{"topic": "..."}` body)
 - Builds a minimal LangGraph state graph with a single `write_haiku` node that calls Azure OpenAI
 - Relies on OneAgent to capture the agent's LLM calls as `gen_ai.*` spans
-- Ships an OpenPipeline config (`openpipeline-langgraph.yaml`) that redacts messages containing secrets on ingest
+- Ships an OpenPipeline config (`openpipeline-langgraph.yaml`) that redacts messages containing secrets on ingest, and also derives the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics (see below)
 
 ## Redacting secrets with OpenPipeline
 
@@ -23,6 +23,10 @@ Because OneAgent sends spans directly to Dynatrace, there is no customer-side co
 | Pipeline | `langgraph-redact-secrets` |
 
 > **Trade-off vs. the collector approach:** OpenPipeline redacts *after* the data reaches Dynatrace, so the raw text travels from the host to the cluster before being masked. If secrets must never leave the host, use the collector-based [`langgraph/opentelemetry`](../opentelemetry) demo, which scrubs before egress.
+
+### Metrics via OpenPipeline
+
+OneAgent captures `gen_ai.*` span attributes here but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. `openpipeline-langgraph.yaml` derives both from these same span attributes, alongside the redaction rules above — in the *same* pipeline object, not a separate one. That's a deliberate choice, not incidental: OpenPipeline's routing table is evaluated first-match, not fan-out, and this demo's routing entry (matched on `dt.service.name`) is more specific than — and ordered ahead of — the generic pipeline the other OneAgent demos share ([`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml)), so langgraph spans would never reach that generic pipeline at all.
 
 ### OpenPipeline implementation notes
 

--- a/langgraph/oneagent/openpipeline-langgraph.yaml
+++ b/langgraph/oneagent/openpipeline-langgraph.yaml
@@ -21,6 +21,15 @@
 #
 # The matcher uses dt.service.name (the OneAgent-detected service display name)
 # combined with dt.openpipeline.source to scope the rule to OneAgent-captured spans only.
+#
+# Also carries the gen_ai.client.token.usage / operation.duration metric
+# extraction (see openpipeline/openpipeline-oneagent-genai-metrics.yaml for the
+# full explanation of the pattern) rather than relying on that generic pipeline:
+# OpenPipeline routing is first-match, not fan-out, and this pipeline's more
+# specific dt.service.name matcher is ordered ahead of the generic one in the
+# routing table — so langgraph/oneagent spans never reach it. langgraph is also
+# the one instrumentation that only ever sets gen_ai.response.model (never
+# request.model), which is why the matchers below check both.
 
 customId: "langgraph-redact-secrets"
 displayName: "LangGraph AI Observability - Redact secrets"
@@ -54,3 +63,90 @@ processing:
       dql:
         script: |
           fieldsAdd gen_ai.system_instructions = if(contains(toString(gen_ai.system_instructions), "secret"), "***REDACTED***", else: gen_ai.system_instructions)
+
+    - id: "oneagent-duration-seconds"
+      enabled: true
+      matcher: "isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model)"
+      type: "dql"
+      description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
+      dql:
+        script: |
+          fieldsAdd duration_seconds = toDouble(duration) / 1000000000.0
+
+metricExtraction:
+  processors:
+
+    - id: "oneagent-operation-duration-metric"
+      enabled: true
+      matcher: "isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model)"
+      type: "samplingAwareHistogramMetric"
+      description: "Extract gen_ai.client.operation.duration from OneAgent GenAI spans"
+      samplingAwareHistogramMetric:
+        metricKey: "gen_ai.client.operation.duration"
+        measurement: "field"
+        field: "duration_seconds"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    - id: "oneagent-token-usage-input-metric"
+      enabled: true
+      matcher: "isNotNull(gen_ai.usage.input_tokens)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (input tokens) from OneAgent GenAI spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.input_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "input"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    - id: "oneagent-token-usage-output-metric"
+      enabled: true
+      matcher: "isNotNull(gen_ai.usage.output_tokens)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (output tokens) from OneAgent GenAI spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.output_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "output"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"

--- a/mistral/oneagent/README.md
+++ b/mistral/oneagent/README.md
@@ -45,3 +45,7 @@ Demonstrates tracing Mistral AI SDK API calls with Dynatrace via OneAgent auto-i
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/ollama/oneagent/README.md
+++ b/ollama/oneagent/README.md
@@ -39,3 +39,7 @@ Demonstrates tracing Ollama SDK API calls with Dynatrace via OneAgent auto-instr
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/openai/oneagent/README.md
+++ b/openai/oneagent/README.md
@@ -39,3 +39,7 @@ Demonstrates tracing OpenAI SDK API calls with Dynatrace via OneAgent auto-instr
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Metrics via OpenPipeline
+
+OneAgent captures the `gen_ai.*` span attributes above, but doesn't emit the `gen_ai.client.token.usage` / `gen_ai.client.operation.duration` metrics the AI Observability app's cost and latency dashboard tiles chart. A shared, tenant-side OpenPipeline pipeline derives both from these same span attributes — deployed once per tenant, not per demo. See [`openpipeline/openpipeline-oneagent-genai-metrics.yaml`](../../openpipeline/openpipeline-oneagent-genai-metrics.yaml) for the pipeline definition and deploy instructions.

--- a/openai/oneagent/app.py
+++ b/openai/oneagent/app.py
@@ -1,7 +1,5 @@
 import os
 import openai
-from openai import Stream
-from openai.types.chat import ChatCompletionChunk
 from fastapi import FastAPI
 from fastapi.responses import PlainTextResponse
 
@@ -32,17 +30,17 @@ async def haiku() -> str:
         )
 
     def _call() -> str:
-        response: Stream[ChatCompletionChunk] = client.chat.completions.create(  # type: ignore[assignment]
+        # Non-streaming: OneAgent's Python OpenAI sensor only fully captures
+        # gen_ai.response.model and token usage in non-streaming mode (see
+        # test/e2e/sdk-analysis/openai-oneagent.md). No behavior change here —
+        # the streaming loop just assembled all chunks synchronously anyway.
+        response = client.chat.completions.create(
             model=MODEL,
             messages=[{"role": "user", "content": "Write a haiku."}],
             max_completion_tokens=20,
-            stream=True,
+            stream=False,
         )
-        result = ""
-        for chunk in response:
-            if chunk.choices and (content := chunk.choices[0].delta.content):
-                result += content
-        return result
+        return response.choices[0].message.content or ""
 
     return await asyncio.to_thread(_call)
 

--- a/openpipeline/README.md
+++ b/openpipeline/README.md
@@ -1,0 +1,18 @@
+# Cross-cutting OpenPipeline configs
+
+OpenPipeline configs here apply tenant-wide, across multiple demos, rather than belonging to one `<sdk>/<instrumentation>/` directory. Per-demo OpenPipeline configs (e.g. `langfuse/opentelemetry/openpipeline-langfuse.yaml`, `langgraph/oneagent/openpipeline-langgraph.yaml`) stay next to the demo they belong to.
+
+## `openpipeline-oneagent-genai-metrics.yaml`
+
+Backfills `gen_ai.client.token.usage` and `gen_ai.client.operation.duration` for every OneAgent demo that doesn't already ship its own OpenPipeline config: `anthropic`, `cohere`, `groq`, `haystack`, `mistral`, `ollama`, `openai`, `aws-bedrock`, `aws-bedrock-agents`, `aws-strands` (all `*/oneagent`).
+
+OneAgent auto-instrumentation captures `gen_ai.*` span attributes but emits neither metric — there's no collector in front of it to derive them from. Both are recoverable tenant-side from attributes OneAgent already sets on the span; see the file's header comment for the extraction pattern (and why the token-usage metric needs two extractors instead of one).
+
+`langgraph/oneagent` is the one OneAgent demo **not** covered by this file — it already has a more specific, higher-priority routing entry for its own pipeline (secret redaction), and OpenPipeline routing is first-match, not fan-out, so its spans never reach this generic pipeline. Its copy of the same three metric extractors lives in `langgraph/oneagent/openpipeline-langgraph.yaml` instead.
+
+Deploy with `dtctl` (see the file's header comment for the exact matcher/routing entry to add):
+
+```bash
+dtctl create settings -f openpipeline/openpipeline-oneagent-genai-metrics.yaml \
+  --schema builtin:openpipeline.spans.pipelines --scope environment
+```

--- a/openpipeline/README.md
+++ b/openpipeline/README.md
@@ -10,9 +10,11 @@ OneAgent auto-instrumentation captures `gen_ai.*` span attributes but emits neit
 
 `langgraph/oneagent` is the one OneAgent demo **not** covered by this file — it already has a more specific, higher-priority routing entry for its own pipeline (secret redaction), and OpenPipeline routing is first-match, not fan-out, so its spans never reach this generic pipeline. Its copy of the same three metric extractors lives in `langgraph/oneagent/openpipeline-langgraph.yaml` instead.
 
-Deploy with `dtctl` (see the file's header comment for the exact matcher/routing entry to add):
+Deploy in your Dynatrace tenant (one-time, per tenant):
 
-```bash
-dtctl create settings -f openpipeline/openpipeline-oneagent-genai-metrics.yaml \
-  --schema builtin:openpipeline.spans.pipelines --scope environment
-```
+1. In Dynatrace press `Ctrl+K` and search for **OpenPipeline**.
+2. Select **Spans**.
+3. Click **Add pipeline**, name it `oneagent-genai-metrics`, and add the processors from `openpipeline-oneagent-genai-metrics.yaml`:
+   - **Processing** tab: the duration-in-seconds conversion.
+   - **Metric extraction** tab: the three metric processors (extracting metrics from spans requires the DPS **Metrics Ingest and Process** rate card).
+4. Go to the **Routing** tab and add an entry — see the file's header comment for the exact matcher.

--- a/openpipeline/openpipeline-oneagent-genai-metrics.yaml
+++ b/openpipeline/openpipeline-oneagent-genai-metrics.yaml
@@ -10,7 +10,8 @@
 # not fan-out, so its spans never reach this one — same extractors live there
 # instead.
 #
-# Deploy (Settings -> OpenPipeline -> Spans), then add a routing entry:
+# Deploy this pipeline in your Dynatrace tenant (Settings -> OpenPipeline -> Spans),
+# then add a routing entry:
 #   Matcher:  dt.openpipeline.source == "oneagent" AND (isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model))
 #   Pipeline: oneagent-genai-metrics
 #

--- a/openpipeline/openpipeline-oneagent-genai-metrics.yaml
+++ b/openpipeline/openpipeline-oneagent-genai-metrics.yaml
@@ -23,8 +23,17 @@
 #
 # Deploy this pipeline in your Dynatrace tenant (Settings -> OpenPipeline -> Spans),
 # then add a routing entry:
-#   Matcher:  dt.openpipeline.source == "oneagent" AND isNotNull(gen_ai.request.model)
+#   Matcher:  dt.openpipeline.source == "oneagent" AND (isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model))
 #   Pipeline: oneagent-genai-metrics
+#
+# Gate on request.model OR response.model, not request.model alone: some
+# instrumentations (e.g. langgraph/oneagent) only ever set response.model on
+# the LLM-invocation span, never request.model. A request.model-only gate
+# silently drops those spans from this pipeline entirely — including their
+# (perfectly present) token counts. Confirmed via CI: PR #174's first run
+# showed langgraph/oneagent with usage.input_tokens/output_tokens present but
+# both metrics absent, root-caused to this matcher excluding the span before
+# either extractor ran.
 
 customId: "oneagent-genai-metrics"
 displayName: "OneAgent GenAI Observability - Metrics"
@@ -43,7 +52,7 @@ processing:
     # ============================================================================
     - id: "oneagent-duration-seconds"
       enabled: true
-      matcher: "isNotNull(gen_ai.request.model)"
+      matcher: "isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model)"
       type: "dql"
       description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
       dql:
@@ -61,7 +70,7 @@ metricExtraction:
 
     - id: "oneagent-operation-duration-metric"
       enabled: true
-      matcher: "isNotNull(gen_ai.request.model)"
+      matcher: "isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model)"
       type: "samplingAwareHistogramMetric"
       description: "Extract gen_ai.client.operation.duration from OneAgent GenAI spans"
       samplingAwareHistogramMetric:

--- a/openpipeline/openpipeline-oneagent-genai-metrics.yaml
+++ b/openpipeline/openpipeline-oneagent-genai-metrics.yaml
@@ -1,46 +1,21 @@
 ---
-# OpenPipeline configuration backfilling the two OTel GenAI client metrics for
-# every OneAgent-instrumented demo that doesn't already have its own dedicated
-# pipeline (anthropic, cohere, groq, haystack, mistral, ollama, openai,
-# aws-bedrock, aws-bedrock-agents, aws-strands).
+# Backfills gen_ai.client.token.usage and gen_ai.client.operation.duration for
+# OneAgent demos without their own OpenPipeline config (anthropic, cohere,
+# groq, haystack, mistral, ollama, openai, aws-bedrock, aws-bedrock-agents,
+# aws-strands). OneAgent emits the gen_ai.* span attributes but not these
+# metrics; both are derived here tenant-side, no app change needed.
 #
-# langgraph/oneagent is the one exception: it already routes through its own
-# langgraph-redact-secrets pipeline (langgraph/oneagent/openpipeline-langgraph.yaml)
-# on a more specific dt.service.name matcher ordered ahead of this one in the
-# routing table. OpenPipeline routing is first-match, not fan-out, so langgraph
-# spans never reach this pipeline — its copy of these same metric extractors
-# lives in that other file instead, not here.
+# langgraph/oneagent is excluded: its own pipeline (openpipeline-langgraph.yaml)
+# has a higher-priority routing entry, and OpenPipeline routing is first-match
+# not fan-out, so its spans never reach this one — same extractors live there
+# instead.
 #
-# OneAgent auto-instrumentation emits the gen_ai.* span attributes but no
-# gen_ai.client.* metrics (no collector sits in front of it to derive them).
-# Both metrics are fully derivable tenant-side from the span attributes
-# OneAgent already emits, so no app-code change is needed:
-#
-#   - gen_ai.client.operation.duration — 1:1 histogram extraction from the
-#     span's own duration (converted from nanoseconds to seconds first).
-#   - gen_ai.client.token.usage — two value-metric extractors writing the same
-#     metric key from gen_ai.usage.input_tokens / output_tokens, each stamping
-#     a constant gen_ai.token.type dimension ("input" / "output"). This is the
-#     "two extractors + dimension alias" pattern — a single numeric attribute
-#     can't carry two dimension values, so each direction gets its own
-#     extractor into the same metricKey.
-#
-# See work/spikes/2026-07-24-genai-metrics-coverage.md (ai-observability-handbook)
-# for the full analysis.
-#
-# Deploy this pipeline in your Dynatrace tenant (Settings -> OpenPipeline -> Spans),
-# then add a routing entry:
+# Deploy (Settings -> OpenPipeline -> Spans), then add a routing entry:
 #   Matcher:  dt.openpipeline.source == "oneagent" AND (isNotNull(gen_ai.request.model) OR isNotNull(gen_ai.response.model))
 #   Pipeline: oneagent-genai-metrics
 #
-# Gate on request.model OR response.model, not request.model alone: some
-# instrumentations (e.g. langgraph/oneagent) only ever set response.model on
-# the LLM-invocation span, never request.model. A request.model-only gate
-# silently drops those spans from this pipeline entirely — including their
-# (perfectly present) token counts. Confirmed via CI: PR #174's first run
-# showed langgraph/oneagent with usage.input_tokens/output_tokens present but
-# both metrics absent, root-caused to this matcher excluding the span before
-# either extractor ran.
+# Matcher checks response.model too — some instrumentations (e.g. langgraph)
+# only ever set that, never request.model.
 
 customId: "oneagent-genai-metrics"
 displayName: "OneAgent GenAI Observability - Metrics"

--- a/openpipeline/openpipeline-oneagent-genai-metrics.yaml
+++ b/openpipeline/openpipeline-oneagent-genai-metrics.yaml
@@ -1,8 +1,15 @@
 ---
 # OpenPipeline configuration backfilling the two OTel GenAI client metrics for
-# every OneAgent-instrumented demo (anthropic, cohere, groq, haystack, mistral,
-# ollama, openai, aws-bedrock, aws-bedrock-agents, aws-strands, langgraph — all
-# */oneagent variants).
+# every OneAgent-instrumented demo that doesn't already have its own dedicated
+# pipeline (anthropic, cohere, groq, haystack, mistral, ollama, openai,
+# aws-bedrock, aws-bedrock-agents, aws-strands).
+#
+# langgraph/oneagent is the one exception: it already routes through its own
+# langgraph-redact-secrets pipeline (langgraph/oneagent/openpipeline-langgraph.yaml)
+# on a more specific dt.service.name matcher ordered ahead of this one in the
+# routing table. OpenPipeline routing is first-match, not fan-out, so langgraph
+# spans never reach this pipeline — its copy of these same metric extractors
+# lives in that other file instead, not here.
 #
 # OneAgent auto-instrumentation emits the gen_ai.* span attributes but no
 # gen_ai.client.* metrics (no collector sits in front of it to derive them).

--- a/openpipeline/openpipeline-oneagent-genai-metrics.yaml
+++ b/openpipeline/openpipeline-oneagent-genai-metrics.yaml
@@ -1,0 +1,144 @@
+---
+# OpenPipeline configuration backfilling the two OTel GenAI client metrics for
+# every OneAgent-instrumented demo (anthropic, cohere, groq, haystack, mistral,
+# ollama, openai, aws-bedrock, aws-bedrock-agents, aws-strands, langgraph — all
+# */oneagent variants).
+#
+# OneAgent auto-instrumentation emits the gen_ai.* span attributes but no
+# gen_ai.client.* metrics (no collector sits in front of it to derive them).
+# Both metrics are fully derivable tenant-side from the span attributes
+# OneAgent already emits, so no app-code change is needed:
+#
+#   - gen_ai.client.operation.duration — 1:1 histogram extraction from the
+#     span's own duration (converted from nanoseconds to seconds first).
+#   - gen_ai.client.token.usage — two value-metric extractors writing the same
+#     metric key from gen_ai.usage.input_tokens / output_tokens, each stamping
+#     a constant gen_ai.token.type dimension ("input" / "output"). This is the
+#     "two extractors + dimension alias" pattern — a single numeric attribute
+#     can't carry two dimension values, so each direction gets its own
+#     extractor into the same metricKey.
+#
+# See work/spikes/2026-07-24-genai-metrics-coverage.md (ai-observability-handbook)
+# for the full analysis.
+#
+# Deploy this pipeline in your Dynatrace tenant (Settings -> OpenPipeline -> Spans),
+# then add a routing entry:
+#   Matcher:  dt.openpipeline.source == "oneagent" AND isNotNull(gen_ai.request.model)
+#   Pipeline: oneagent-genai-metrics
+
+customId: "oneagent-genai-metrics"
+displayName: "OneAgent GenAI Observability - Metrics"
+
+processing:
+  processors:
+
+    # ============================================================================
+    # DURATION IN SECONDS (feeds the operation-duration metric below)
+    # ============================================================================
+    # The span `duration` field is in nanoseconds. The metric-extraction
+    # "duration" measurement emits MICROSECONDS, but the OTel semconv metric
+    # gen_ai.client.operation.duration (and every native SDK emitter) is in
+    # SECONDS. Materialize a seconds value here and point the metric at it via
+    # measurement: "field" (same fix as openpipeline-langfuse.yaml, PR #166).
+    # ============================================================================
+    - id: "oneagent-duration-seconds"
+      enabled: true
+      matcher: "isNotNull(gen_ai.request.model)"
+      type: "dql"
+      description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
+      dql:
+        script: |
+          fieldsAdd duration_seconds = toDouble(duration) / 1000000000.0
+
+# ==============================================================================
+# METRIC EXTRACTION
+# ==============================================================================
+# OneAgent spans never reach a collector, so neither metric is produced
+# natively. Both are re-created here from attributes OneAgent already emits.
+# ==============================================================================
+metricExtraction:
+  processors:
+
+    - id: "oneagent-operation-duration-metric"
+      enabled: true
+      matcher: "isNotNull(gen_ai.request.model)"
+      type: "samplingAwareHistogramMetric"
+      description: "Extract gen_ai.client.operation.duration from OneAgent GenAI spans"
+      samplingAwareHistogramMetric:
+        metricKey: "gen_ai.client.operation.duration"
+        measurement: "field"
+        field: "duration_seconds"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    # ============================================================================
+    # TOKEN USAGE — two extractors, same metric key, aliased dimension
+    # ============================================================================
+    # A span carries gen_ai.usage.input_tokens and gen_ai.usage.output_tokens as
+    # two separate numeric fields with no token-type dimension of their own. The
+    # app queries one dimensioned metric (`sum(gen_ai.client.token.usage)` filtered
+    # by `gen_ai.token.type`), so each direction gets its own extractor into the
+    # same metricKey, with a constant dimension value naming which one it is.
+    # ============================================================================
+    - id: "oneagent-token-usage-input-metric"
+      enabled: true
+      matcher: "isNotNull(gen_ai.usage.input_tokens)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (input tokens) from OneAgent GenAI spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.input_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "input"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    - id: "oneagent-token-usage-output-metric"
+      enabled: true
+      matcher: "isNotNull(gen_ai.usage.output_tokens)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (output tokens) from OneAgent GenAI spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.output_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "output"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"

--- a/test/e2e/anthropic_oneagent_test.go
+++ b/test/e2e/anthropic_oneagent_test.go
@@ -8,7 +8,7 @@ func TestAnthropicOneAgent(t *testing.T) {
 	startApp(t, "anthropic/oneagent")
 	triggerHaiku(t, true)
 
-	auditSpan(t, "anthropic", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "anthropic", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "anthropic/oneagent"
 | filter (gen_ai.provider.name == "anthropic" or gen_ai.system == "anthropic") and dt.openpipeline.source == "oneagent"
@@ -16,5 +16,6 @@ func TestAnthropicOneAgent(t *testing.T) {
 | filter isNotNull(dt.smartscape.service)
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+		"anthropic/oneagent", genAIClientMetrics)
 }

--- a/test/e2e/aws_bedrock_agents_oneagent_test.go
+++ b/test/e2e/aws_bedrock_agents_oneagent_test.go
@@ -15,7 +15,7 @@ func TestAWSBedrockAgentsOneAgent(t *testing.T) {
 	// unspecified, and the guardrail-blocked trace is missing several
 	// baseline attributes (e.g. token usage), which would flip this audit's
 	// verdict independent of any real regression.
-	auditSpan(t, "aws-bedrock-agents", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "aws-bedrock-agents", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock-agents/oneagent"
 | filter (gen_ai.provider.name == "aws_bedrock") and dt.openpipeline.source == "oneagent"
@@ -23,7 +23,8 @@ func TestAWSBedrockAgentsOneAgent(t *testing.T) {
 | filter isNotNull(dt.smartscape.service)
 | filter isNull(span.status_code) or span.status_code != "error"
 | sort start_time asc
-| limit 1`)
+| limit 1`,
+		"aws-bedrock-agents/oneagent", genAIClientMetrics)
 
 	// The guardrail-triggering request is always sent last, so the latest
 	// matching span is the one that actually tripped the guardrail.

--- a/test/e2e/aws_bedrock_oneagent_test.go
+++ b/test/e2e/aws_bedrock_oneagent_test.go
@@ -15,7 +15,7 @@ func TestAWSBedrockOneAgent(t *testing.T) {
 	// unspecified, and the guardrail-blocked trace is missing several
 	// baseline attributes (e.g. token usage), which would flip this audit's
 	// verdict independent of any real regression.
-	auditSpan(t, "aws-bedrock", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "aws-bedrock", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock/oneagent"
 | filter (gen_ai.provider.name == "aws_bedrock" or gen_ai.system == "aws_bedrock") and dt.openpipeline.source == "oneagent"
@@ -23,7 +23,8 @@ func TestAWSBedrockOneAgent(t *testing.T) {
 | filter isNotNull(dt.smartscape.service)
 | filter isNull(span.status_code) or span.status_code != "error"
 | sort start_time asc
-| limit 1`)
+| limit 1`,
+		"aws-bedrock/oneagent", genAIClientMetrics)
 
 	// The guardrail-triggering request is always sent last, so the latest
 	// matching span is the one that actually tripped the guardrail.

--- a/test/e2e/aws_strands_oneagent_test.go
+++ b/test/e2e/aws_strands_oneagent_test.go
@@ -38,5 +38,6 @@ func TestAWSStrandsOneAgent(t *testing.T) {
 
 	// gen_ai.bedrock.guardrail.* (AR-017/AR-018/AR-019) are not emitted
 	// because the demo does not configure Bedrock guardrails — expected FAIL in report.
-	auditSpan(t, "aws-strands", "oneagent", BedrockProfile, awsStrandsDQL)
+	auditSpanWithMetrics(t, "aws-strands", "oneagent", BedrockProfile, awsStrandsDQL,
+		"aws-strands/oneagent", genAIClientMetrics)
 }

--- a/test/e2e/cohere_test.go
+++ b/test/e2e/cohere_test.go
@@ -9,7 +9,7 @@ func TestCohereOneAgent(t *testing.T) {
 	startApp(t, "cohere/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "cohere", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "cohere", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "cohere/oneagent"
 | filter gen_ai.provider.name == "cohere" or gen_ai.system == "cohere"
@@ -19,5 +19,6 @@ func TestCohereOneAgent(t *testing.T) {
 | filter isNull(span.status_code) or span.status_code != "error"
 | sort timestamp desc
 | limit 1`,
+		"cohere/oneagent", genAIClientMetrics,
 		"Backend mocked: in-process httptest stub intercepts Cohere SDK calls via CO_API_URL. Replace with a real COHERE_API_KEY secret for live validation.")
 }

--- a/test/e2e/groq_test.go
+++ b/test/e2e/groq_test.go
@@ -9,7 +9,7 @@ func TestGroqOneAgent(t *testing.T) {
 	startApp(t, "groq/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "groq", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "groq", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "groq/oneagent"
 | filter gen_ai.provider.name == "groq" or gen_ai.system == "groq"
@@ -19,5 +19,6 @@ func TestGroqOneAgent(t *testing.T) {
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
 | limit 1`,
+		"groq/oneagent", genAIClientMetrics,
 		"Backend mocked: ollama running tinyllama locally serves Groq-compatible requests via GROQ_BASE_URL. Replace with a real GROQ_API_KEY secret for live validation.")
 }

--- a/test/e2e/haystack_test.go
+++ b/test/e2e/haystack_test.go
@@ -8,7 +8,7 @@ func TestHaystackOneAgent(t *testing.T) {
 	startApp(t, "haystack/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "haystack", "oneagent", AzureProfile,
+	auditSpanWithMetrics(t, "haystack", "oneagent", AzureProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "haystack/oneagent"
 | filter dt.openpipeline.source == "oneagent"
@@ -17,5 +17,6 @@ func TestHaystackOneAgent(t *testing.T) {
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
 | limit 1`,
+		"haystack/oneagent", genAIClientMetrics,
 		"gen_ai.system expected to be az.ai.openai — OneAgent instruments the underlying openai SDK calls made by AzureOpenAIGenerator; confirm with ICP-6026.")
 }

--- a/test/e2e/langgraph_oneagent_test.go
+++ b/test/e2e/langgraph_oneagent_test.go
@@ -48,7 +48,7 @@ func TestLangGraphOneAgent(t *testing.T) {
 | filter contains(toString(`+"`gen_ai.input.messages`"+`), "launch codes")
 | limit 1`))
 
-	auditSpan(t, "langgraph", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "langgraph", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "langgraph/oneagent"
 | filter dt.openpipeline.source == "oneagent"
@@ -56,5 +56,6 @@ func TestLangGraphOneAgent(t *testing.T) {
 | filter isNotNull(dt.smartscape.service)
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+		"langgraph/oneagent", genAIClientMetrics)
 }

--- a/test/e2e/mistral_test.go
+++ b/test/e2e/mistral_test.go
@@ -9,7 +9,7 @@ func TestMistralOneAgent(t *testing.T) {
 	startApp(t, "mistral/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "mistral", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "mistral", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "mistral/oneagent"
 | filter (gen_ai.provider.name == "mistralai" or gen_ai.system == "mistralai") and dt.openpipeline.source == "oneagent"
@@ -18,5 +18,6 @@ func TestMistralOneAgent(t *testing.T) {
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
 | limit 1`,
+		"mistral/oneagent", genAIClientMetrics,
 		"Backend mocked: in-process httptest stub intercepts Mistral SDK calls via MISTRAL_BASE_URL. Replace with a real MISTRAL_API_KEY secret for live validation.")
 }

--- a/test/e2e/ollama_test.go
+++ b/test/e2e/ollama_test.go
@@ -8,12 +8,13 @@ func TestOllamaOneAgent(t *testing.T) {
 	startApp(t, "ollama/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "ollama", "oneagent", GenericProfile,
+	auditSpanWithMetrics(t, "ollama", "oneagent", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "ollama/oneagent"
 | filter (gen_ai.provider.name == "ollama" or gen_ai.system == "ollama") and dt.openpipeline.source == "oneagent"
 | filter isNotNull(gen_ai.request.model)
 | filter isNotNull(dt.smartscape.service)
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+		"ollama/oneagent", genAIClientMetrics)
 }

--- a/test/e2e/openai_oneagent_test.go
+++ b/test/e2e/openai_oneagent_test.go
@@ -8,7 +8,7 @@ func TestOpenAIOneAgent(t *testing.T) {
 	startApp(t, "openai/oneagent")
 	triggerHaiku(t, false)
 
-	auditSpan(t, "openai", "oneagent", OpenAIProfile,
+	auditSpanWithMetrics(t, "openai", "oneagent", OpenAIProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "openai/oneagent"
 | filter dt.openpipeline.source == "oneagent"
@@ -16,5 +16,6 @@ func TestOpenAIOneAgent(t *testing.T) {
 | filter isNotNull(dt.smartscape.service)
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+		"openai/oneagent", genAIClientMetrics)
 }


### PR DESCRIPTION
## Summary
- OneAgent (`*/oneagent`: anthropic, cohere, groq, haystack, mistral, ollama, openai, aws-bedrock, aws-bedrock-agents, aws-strands, langgraph) emits `gen_ai.*` span attributes but no `gen_ai.client.*` metrics — no collector sits in front of it to derive them, so the cost/latency dashboard tiles are silently empty for every OneAgent demo.
- Adds `openpipeline/openpipeline-oneagent-genai-metrics.yaml`: one tenant-side OpenPipeline pipeline deriving both `gen_ai.client.operation.duration` (1:1 histogram from span duration, ns→s converted) and `gen_ai.client.token.usage` (two `samplingAwareValueMetric` extractors — same metric key, each with a constant `gen_ai.token.type` dimension — since a span carries `input_tokens`/`output_tokens` as separate numeric fields with no type dimension of its own). No app-code changes.
- Wires all 11 OneAgent e2e tests to assert both metrics via the existing `auditSpanWithMetrics`/`genAIClientMetrics` helper (added in #164, previously unused by any OneAgent test).
- Pipeline already deployed + verified on the sprint tenant 

## Test plan
- [x] `go build ./...` / `go vet ./...` clean on `test/e2e`
- [x] Pipeline + routing entry created and verified via `dtctl` against sprint tenant `ixq6468h`
- [ ] CI e2e run (triggered by this PR) — watching results next