### PR TITLE
Backfill genai metrics

### DIFF
--- a/aws-bedrock/openinference/Makefile
+++ b/aws-bedrock/openinference/Makefile
@@ -9,10 +9,10 @@ PORT             ?= 8000
 DT_ENDPOINT      ?= https://your-tenant.live.dynatrace.com
 DT_API_TOKEN     ?= dt0c01.*****
 
-# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.104.0 tracks OTel
-# contrib v0.156.0 and bundles genainormalizerprocessor. Pinned so a version
-# bump surfaces normalization regressions in the e2e test.
-override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.104.0
+# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.105.0 tracks OTel
+# contrib v0.157.0 and bundles genainormalizerprocessor + signal_to_metrics
+# connector. Pinned so a version bump surfaces normalization regressions in the e2e test.
+override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.105.0
 override COLLECTOR_CONTAINER := bindplane-otel-collector
 
 .PHONY: install run build push request stop logs help

--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -64,18 +64,19 @@ connectors:
   # Token usage: OpenInference is span-only (no metric instruments). Re-create
   # gen_ai.client.token.usage from the span token attributes with two sum defs
   # sharing one metric name; the gen_ai.token.type dimension is synthesized per
-  # direction via default_value. signaltometrics emits delta per batch, which
+  # direction via default_value. signal_to_metrics emits delta per batch, which
   # Dynatrace requires. Collector-path equivalent of the OpenPipeline
   # two-extractor pattern.
-  signaltometrics:
+  signal_to_metrics:
     spans:
       - name: gen_ai.client.token.usage
-        description: GenAI input token usage
-        unit: "1"
-        # include_resource_attributes is per-metric (not a connector-level key);
-        # setting it here keeps service.name on the output metric.
-        include_resource_attributes:
-          - key: service.name
+        description: "Number of tokens used per LLM call, by direction"
+        unit: "{token}"
+        conditions:
+          - attributes["gen_ai.usage.input_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.input_tokens"])
+          monotonic: true
         attributes:
           - key: gen_ai.token.type
             default_value: input
@@ -83,16 +84,14 @@ connectors:
           - key: gen_ai.response.model
           - key: gen_ai.provider.name
           - key: gen_ai.operation.name
-        conditions:
-          - attributes["gen_ai.usage.input_tokens"] != nil
-        sum:
-          value: Int(attributes["gen_ai.usage.input_tokens"])
-          monotonic: true
       - name: gen_ai.client.token.usage
-        description: GenAI output token usage
-        unit: "1"
-        include_resource_attributes:
-          - key: service.name
+        description: "Number of tokens used per LLM call, by direction"
+        unit: "{token}"
+        conditions:
+          - attributes["gen_ai.usage.output_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.output_tokens"])
+          monotonic: true
         attributes:
           - key: gen_ai.token.type
             default_value: output
@@ -100,11 +99,8 @@ connectors:
           - key: gen_ai.response.model
           - key: gen_ai.provider.name
           - key: gen_ai.operation.name
-        conditions:
-          - attributes["gen_ai.usage.output_tokens"] != nil
-        sum:
-          value: Int(attributes["gen_ai.usage.output_tokens"])
-          monotonic: true
+      # service.name is a resource attribute included by default — no
+      # include_resource_attributes filter needed, same as spanmetrics.
 
 exporters:
   otlp_http/dynatrace:
@@ -124,9 +120,9 @@ service:
     traces/genai_metrics:
       receivers: [otlp]
       processors: [gen_ai_normalizer, transform/response_model, filter/genai_only, batch]
-      exporters: [spanmetrics, signaltometrics]
+      exporters: [spanmetrics, signal_to_metrics]
     metrics:
-      receivers: [otlp, spanmetrics, signaltometrics]
+      receivers: [otlp, spanmetrics, signal_to_metrics]
       exporters: [otlp_http/dynatrace]
     logs:
       receivers: [otlp]

--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -33,6 +33,75 @@ processors:
     send_batch_size: 512
     timeout: 5s
 
+  # Keep only spans that represent an LLM call (gen_ai.request.model is set by the
+  # normalizer on LLM spans). Feeds the metrics connectors so the derived metrics
+  # cover LLM calls only. Used solely on the metrics branch — the export pipeline
+  # is left untouched so all spans still reach Distributed Tracing.
+  filter/genai_only:
+    error_mode: ignore
+    traces:
+      span:
+        - attributes["gen_ai.request.model"] == nil
+
+connectors:
+  # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
+  # from the LLM span durations — same connector the langfuse demo uses.
+  spanmetrics:
+    namespace: gen_ai.client.operation
+    # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      unit: s
+      explicit:
+        buckets: [100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 30s, 60s]
+    dimensions:
+      - name: gen_ai.request.model
+      - name: gen_ai.response.model
+      - name: gen_ai.provider.name
+      - name: gen_ai.operation.name
+    metrics_flush_interval: 15s
+
+  # Token usage: OpenInference is span-only (no metric instruments). Re-create
+  # gen_ai.client.token.usage from the span token attributes with two sum defs
+  # sharing one metric name; the gen_ai.token.type dimension is synthesized per
+  # direction via default_value. signaltometrics emits delta per batch, which
+  # Dynatrace requires. Collector-path equivalent of the OpenPipeline
+  # two-extractor pattern.
+  signaltometrics:
+    include_resource_attributes:
+      - key: service.name
+    spans:
+      - name: gen_ai.client.token.usage
+        description: GenAI input token usage
+        unit: "1"
+        attributes:
+          - key: gen_ai.token.type
+            default_value: input
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+        conditions:
+          - attributes["gen_ai.usage.input_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.input_tokens"])
+          monotonic: true
+      - name: gen_ai.client.token.usage
+        description: GenAI output token usage
+        unit: "1"
+        attributes:
+          - key: gen_ai.token.type
+            default_value: output
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+        conditions:
+          - attributes["gen_ai.usage.output_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.output_tokens"])
+          monotonic: true
+
 exporters:
   otlp_http/dynatrace:
     endpoint: "${env:DT_ENDPOINT}/api/v2/otlp"
@@ -45,8 +114,15 @@ service:
       receivers: [otlp]
       processors: [gen_ai_normalizer, transform/response_model, batch]
       exporters: [otlp_http/dynatrace]
-    metrics:
+    # Second branch of the same spans: normalize, keep only LLM spans, and feed
+    # the metric connectors. Kept separate from the export pipeline so the filter
+    # here never drops spans from Distributed Tracing.
+    traces/genai_metrics:
       receivers: [otlp]
+      processors: [gen_ai_normalizer, transform/response_model, filter/genai_only, batch]
+      exporters: [spanmetrics, signaltometrics]
+    metrics:
+      receivers: [otlp, spanmetrics, signaltometrics]
       exporters: [otlp_http/dynatrace]
     logs:
       receivers: [otlp]

--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -68,12 +68,14 @@ connectors:
   # Dynatrace requires. Collector-path equivalent of the OpenPipeline
   # two-extractor pattern.
   signaltometrics:
-    include_resource_attributes:
-      - key: service.name
     spans:
       - name: gen_ai.client.token.usage
         description: GenAI input token usage
         unit: "1"
+        # include_resource_attributes is per-metric (not a connector-level key);
+        # setting it here keeps service.name on the output metric.
+        include_resource_attributes:
+          - key: service.name
         attributes:
           - key: gen_ai.token.type
             default_value: input
@@ -89,6 +91,8 @@ connectors:
       - name: gen_ai.client.token.usage
         description: GenAI output token usage
         unit: "1"
+        include_resource_attributes:
+          - key: service.name
         attributes:
           - key: gen_ai.token.type
             default_value: output

--- a/aws-strands/opentelemetry/Makefile
+++ b/aws-strands/opentelemetry/Makefile
@@ -5,7 +5,12 @@ export
 DT_ENDPOINT      ?= https://your-tenant.live.dynatrace.com
 DT_API_TOKEN     ?= dt0c01.*****
 
-override COLLECTOR_IMAGE     := ghcr.io/dynatrace/dynatrace-otel-collector/dynatrace-otel-collector:0.51.0
+# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.104.0 tracks OTel
+# contrib v0.156.0 and bundles the signaltometrics connector used to derive
+# gen_ai.client.token.usage from span attributes — that connector is NOT in the
+# Dynatrace collector distro, so this demo runs Bindplane. Pinned so a version
+# bump surfaces metric-derivation regressions in the e2e test.
+override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.104.0
 override COLLECTOR_CONTAINER := otel-collector
 
 # Downstream 'appointments' service the create_appointment tool calls.
@@ -83,10 +88,10 @@ _collector:
 	docker run -d \
 	  --name $(COLLECTOR_CONTAINER) \
 	  -p 4318:4318 \
-	  -v $$(pwd)/$(CONFIG):/etc/otelcol/otel-collector-config.yaml:ro \
+	  -v $$(pwd)/$(CONFIG):/etc/otel/config.yaml:ro \
 	  -e DT_ENDPOINT=$(DT_ENDPOINT) \
 	  -e DT_API_TOKEN=$(DT_API_TOKEN) \
-	  $(COLLECTOR_IMAGE) --config=/etc/otelcol/otel-collector-config.yaml && \
+	  $(COLLECTOR_IMAGE) && \
 	docker logs -f $(COLLECTOR_CONTAINER) > collector.log 2>&1 & \
 	echo "Collector logs -> collector.log" && \
 	for i in $$(seq 1 30); do \

--- a/aws-strands/opentelemetry/README.md
+++ b/aws-strands/opentelemetry/README.md
@@ -19,7 +19,7 @@ With the opt-in configured in [`dynatrace.py`](./dynatrace.py) (see the note bel
 - [Prerequisites](#prerequisites)
 - [Configuration options](#configuration-options)
 - [Setup](#setup)
-- [Option A: OTel Collector with transform processor](#option-a-otel-collector-with-transform-processor)
+- [Option A: Bindplane Collector with transform processor](#option-a-bindplane-collector-with-transform-processor)
 - [Option B: Dynatrace OpenPipeline](#option-b-dynatrace-openpipeline)
 - [Visualize in Dynatrace AI Observability](#visualize-in-dynatrace-ai-observability)
 - [Attribute mapping reference](#attribute-mapping-reference)
@@ -33,7 +33,7 @@ With the opt-in configured in [`dynatrace.py`](./dynatrace.py) (see the note bel
 - Runs a multi-turn Personal Assistant Agent using Strands Agents on Amazon Bedrock.
 - Produces OpenTelemetry traces with `gen_ai.*` attributes, including `gen_ai.input.messages` / `gen_ai.output.messages` message content (via the `OTEL_SEMCONV_STABILITY_OPT_IN` opt-in).
 - Calls a small local **appointments service** from the `create_appointment` tool, so the tool call becomes a real downstream span and the trace spans two services. The Makefile starts and stops this service for you.
-- Normalizes Strands attributes to Dynatrace `gen_ai.*` format; either via a local OTel Collector or via Dynatrace OpenPipeline.
+- Normalizes Strands attributes to Dynatrace `gen_ai.*` format; either via a local Bindplane Collector or via Dynatrace OpenPipeline.
 - Shows the full agentic trace in the Dynatrace AI Observability app including tool calls, cycle spans, model invocations, token usage, and message content.
 
 > [!NOTE]
@@ -54,7 +54,7 @@ With the opt-in configured in [`dynatrace.py`](./dynatrace.py) (see the note bel
 
 Strands Agents uses its own span attribute conventions that the Dynatrace AI Observability app does not natively understand. Two equivalent approaches normalize the attributes:
 
-|  | Option A: OTel Collector | Option B: OpenPipeline |
+|  | Option A: Bindplane Collector | Option B: OpenPipeline |
 |---|---|---|
 | **Where transforms run** | In the collector process, before ingest | Server-side, in your Dynatrace tenant |
 | **Requires Docker** | Yes | No |
@@ -109,19 +109,19 @@ make install
 
 ---
 
-## Option A: OTel Collector with transform processor
+## Option A: Bindplane Collector with transform processor
 
-The OTel Collector intercepts spans and applies all Strands → `gen_ai.*` attribute mappings before forwarding to Dynatrace, and derives the two `gen_ai.client.*` metrics from the spans. No Dynatrace configuration needed.
+The Bindplane Collector intercepts spans and applies all Strands → `gen_ai.*` attribute mappings before forwarding to Dynatrace, and derives the two `gen_ai.client.*` metrics from the spans. No Dynatrace configuration needed.
 
 ```
-App  →  Strands SDK (OTLP export)  →  OTel Collector (transform + metric connectors)  →  Dynatrace Grail
+App  →  Strands SDK (OTLP export)  →  Bindplane Collector (transform + metric connectors)  →  Dynatrace Grail
 ```
 
 ```bash
 make run
 ```
 
-The collector listens on port `4318`. The `transform/strands` processor remaps non-standard Strands attributes to `gen_ai.*`, and the `spanmetrics` / `signaltometrics` connectors derive the `gen_ai.client.*` metrics (see [Metrics](#metrics)), before forwarding to Dynatrace. This demo runs the **Bindplane** collector image (`ghcr.io/observiq/bindplane-agent`) because `signaltometrics` — needed for the token metric — is not in the Dynatrace collector distro.
+The collector listens on port `4318`. The `transform/strands` processor remaps non-standard Strands attributes to `gen_ai.*`, and the `spanmetrics` / `signaltometrics` connectors derive the `gen_ai.client.*` metrics (see [Metrics](#metrics)), before forwarding to Dynatrace. This demo runs the **Bindplane** collector image (`ghcr.io/observiq/bindplane-agent`).
 
 **Useful commands:**
 
@@ -210,7 +210,7 @@ Strands emits `gen_ai.*` span attributes and its own `strands.*` metrics, but no
 - Option B: run `uv run python3 main.py` with env vars set; any auth error appears in the console.
 
 **Collector crashes on startup (Option A):**
-- Run `docker ps -a` and `docker logs otel-collector` to see the error.
+- Run `docker ps -a` and `docker logs bindplane-collector` to see the error.
 - Confirm Docker is running and port `4318` is free: `lsof -i :4318`.
 
 **Spans in Distributed Tracing but not in AI Observability:**

--- a/aws-strands/opentelemetry/README.md
+++ b/aws-strands/opentelemetry/README.md
@@ -23,6 +23,7 @@ With the opt-in configured in [`dynatrace.py`](./dynatrace.py) (see the note bel
 - [Option B: Dynatrace OpenPipeline](#option-b-dynatrace-openpipeline)
 - [Visualize in Dynatrace AI Observability](#visualize-in-dynatrace-ai-observability)
 - [Attribute mapping reference](#attribute-mapping-reference)
+- [Metrics](#metrics)
 - [Troubleshooting](#troubleshooting)
 
 ---
@@ -36,7 +37,7 @@ With the opt-in configured in [`dynatrace.py`](./dynatrace.py) (see the note bel
 - Shows the full agentic trace in the Dynatrace AI Observability app including tool calls, cycle spans, model invocations, token usage, and message content.
 
 > [!NOTE]
-> This example uses `strands-agents` 1.x, which configures OpenTelemetry via `StrandsTelemetry` (`setup_otlp_exporter()` + `setup_meter()`) and requires the `opentelemetry-exporter-otlp-proto-http` package. Strands emits its own `strands.*` metrics (for example `strands.event_loop.input.tokens`), **not** the OTel semconv `gen_ai.client.*` metrics the AI Observability app charts. The app's metric tiles for this example therefore rely on the OpenPipeline span-to-metric extraction described below, not on native SDK metrics.
+> This example uses `strands-agents` 1.x, which configures OpenTelemetry via `StrandsTelemetry` (`setup_otlp_exporter()` + `setup_meter()`) and requires the `opentelemetry-exporter-otlp-proto-http` package. Strands emits its own `strands.*` metrics (for example `strands.event_loop.input.tokens`), **not** the OTel semconv `gen_ai.client.*` metrics the AI Observability app charts. Both options below re-create the two metrics the app needs — `gen_ai.client.token.usage` and `gen_ai.client.operation.duration` — from the Strands spans: Option A in the collector (`spanmetrics` + `signaltometrics` connectors), Option B server-side in OpenPipeline (span-to-metric extraction). See [Metrics](#metrics).
 
 ---
 
@@ -110,17 +111,17 @@ make install
 
 ## Option A: OTel Collector with transform processor
 
-The OTel Collector intercepts spans and applies all Strands → `gen_ai.*` attribute mappings before forwarding to Dynatrace. No Dynatrace configuration needed.
+The OTel Collector intercepts spans and applies all Strands → `gen_ai.*` attribute mappings before forwarding to Dynatrace, and derives the two `gen_ai.client.*` metrics from the spans. No Dynatrace configuration needed.
 
 ```
-App  →  Strands SDK (OTLP export)  →  OTel Collector (transform processor)  →  Dynatrace Grail
+App  →  Strands SDK (OTLP export)  →  OTel Collector (transform + metric connectors)  →  Dynatrace Grail
 ```
 
 ```bash
 make run
 ```
 
-The collector listens on port `4318`. The `transform/strands` processor remaps non-standard Strands attributes to `gen_ai.*` before forwarding to Dynatrace.
+The collector listens on port `4318`. The `transform/strands` processor remaps non-standard Strands attributes to `gen_ai.*`, and the `spanmetrics` / `signaltometrics` connectors derive the `gen_ai.client.*` metrics (see [Metrics](#metrics)), before forwarding to Dynatrace. This demo runs the **Bindplane** collector image (`ghcr.io/observiq/bindplane-agent`) because `signaltometrics` — needed for the token metric — is not in the Dynatrace collector distro.
 
 **Useful commands:**
 
@@ -182,6 +183,21 @@ make run-openpipeline
 | `tool.parameters` | `gen_ai.tool.call.arguments` | OpenPipeline only |
 | `gen_ai.agent.name` | `gen_ai.agent.name` | Passed through; non-namespaced `agent.name` copy removed |
 | _(hardcoded)_ | `ai.observability.source = "strands-agents"` | Set on all Strands spans (OpenPipeline only) |
+
+---
+
+## Metrics
+
+Strands emits `gen_ai.*` span attributes and its own `strands.*` metrics, but not the two OTel semconv metrics the AI Observability app charts. Both options re-create them from the spans, so the cost and latency tiles populate either way:
+
+| Metric | Option A (collector) | Option B (OpenPipeline) |
+|---|---|---|
+| `gen_ai.client.operation.duration` (s) | `spanmetrics` connector, on `Model invoke` spans | `samplingAwareHistogramMetric` extractor on `duration_seconds` |
+| `gen_ai.client.token.usage` (`gen_ai.token.type` = `input`/`output`) | `signaltometrics` connector, two sum defs | two `samplingAwareValueMetric` extractors, one per direction |
+
+**Option A** derives both metrics in the collector. `gen_ai.client.token.usage` needs the `signaltometrics` connector, which ships in the **Bindplane** collector (`ghcr.io/observiq/bindplane-agent`) but **not** in the Dynatrace collector distro — this is why the Makefile pins the Bindplane image. Requires the token's `metrics.ingest` scope. Both metrics use delta temporality (Dynatrace rejects cumulative).
+
+**Option B** derives the same two metrics server-side from the ingested spans via the metric-extraction processors in [`openpipeline-strands.yaml`](openpipeline-strands.yaml) — no collector required. The token metric uses the two-extractor pattern (one extractor per direction, both writing `gen_ai.client.token.usage` with a constant `gen_ai.token.type` dimension).
 
 ---
 

--- a/aws-strands/opentelemetry/openpipeline-strands.yaml
+++ b/aws-strands/opentelemetry/openpipeline-strands.yaml
@@ -147,3 +147,120 @@ processing:
       dql:
         script: |
           fieldsAdd `ai.observability.source` = "strands-agents"
+
+    # ============================================================================
+    # 8. DURATION IN SECONDS (feeds the operation-duration metric below)
+    # ============================================================================
+    # The span `duration` field is in nanoseconds. The metric-extraction
+    # "duration" measurement emits MICROSECONDS, but the OTel semconv metric
+    # gen_ai.client.operation.duration (and every native SDK emitter) is in
+    # SECONDS. Materialize a seconds value here and point the metric at it via
+    # measurement: "field" (same fix as openpipeline-langfuse.yaml, PR #166).
+    # Scoped to Model invoke spans — the LLM call is the unit the duration and
+    # token metrics describe.
+    # ============================================================================
+    - id: "strands-duration-seconds"
+      enabled: true
+      matcher: 'span.name == "Model invoke"'
+      type: "dql"
+      description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
+      dql:
+        script: |
+          fieldsAdd duration_seconds = toDouble(duration) / 1000000000.0
+
+# ==============================================================================
+# METRIC EXTRACTION
+# ==============================================================================
+# Strands 1.x emits gen_ai.* spans but not the gen_ai.client.* metrics the AI
+# Observability app queries (its native metrics live under strands.* names).
+# Both metrics are re-created here from the normalized attributes above, the
+# same tenant-side two-extractor pattern used for OneAgent
+# (openpipeline/openpipeline-oneagent-genai-metrics.yaml).
+# ==============================================================================
+metricExtraction:
+  processors:
+
+    - id: "strands-operation-duration-metric"
+      enabled: true
+      matcher: 'span.name == "Model invoke"'
+      type: "samplingAwareHistogramMetric"
+      description: "Extract gen_ai.client.operation.duration from Strands model-invoke spans"
+      samplingAwareHistogramMetric:
+        metricKey: "gen_ai.client.operation.duration"
+        measurement: "field"
+        field: "duration_seconds"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    # ============================================================================
+    # TOKEN USAGE — two extractors, same metric key, aliased dimension
+    # ============================================================================
+    # A span carries gen_ai.usage.input_tokens and gen_ai.usage.output_tokens as
+    # two separate numeric fields with no token-type dimension of their own. The
+    # app queries one dimensioned metric (`sum(gen_ai.client.token.usage)` filtered
+    # by `gen_ai.token.type`), so each direction gets its own extractor into the
+    # same metricKey, with a constant dimension value naming which one it is.
+    # (Token attributes were normalized to gen_ai.usage.* in step 4 above.)
+    # ============================================================================
+    - id: "strands-token-usage-input-metric"
+      enabled: true
+      matcher: "isNotNull(`gen_ai.usage.input_tokens`)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (input tokens) from Strands spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.input_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "input"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    - id: "strands-token-usage-output-metric"
+      enabled: true
+      matcher: "isNotNull(`gen_ai.usage.output_tokens`)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (output tokens) from Strands spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.output_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "output"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"

--- a/aws-strands/opentelemetry/openpipeline-strands.yaml
+++ b/aws-strands/opentelemetry/openpipeline-strands.yaml
@@ -10,17 +10,20 @@
 #   Matcher:  gen_ai.provider.name == "strands-agents"
 #   Pipeline: strands-agents-ai-spans
 #
+# Note: Strands 1.x with gen_ai_latest_experimental emits gen_ai.provider.name
+# (not gen_ai.system). Use gen_ai.provider.name in the routing matcher.
+#
 # The app is configured (OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental,
 # gen_ai_span_attributes_only) so Strands 1.x emits gen_ai.input.messages /
 # gen_ai.output.messages directly as span attributes. Latest conventions replace
 # gen_ai.system with gen_ai.provider.name == "strands-agents", which identifies
 # Strands spans both at routing time and for every processor matcher below.
 #
-# Strands span types and their naming patterns:
-#   Agent span   — named after the agent (e.g. "Strands Agent")
-#   Model invoke — span.name == "Model invoke"
-#   Tool span    — span.name starts with "Tool: "
-#   Cycle span   — span.name starts with "Cycle "
+# Strands 1.x span names (gen_ai_latest_experimental semconv):
+#   LLM call     — span.name == "chat"
+#   Tool span    — span.name starts with "execute_tool "
+#   Cycle span   — span.name == "execute_event_loop_cycle"
+#   Agent span   — span.name starts with "invoke_agent "
 
 customId: "strands-agents-ai-spans"
 displayName: "AWS Strands Agents AI Observability - Spans"
@@ -51,11 +54,11 @@ processing:
     # ============================================================================
     # Infer gen_ai.operation.name and gen_ai.operation.kind from span name.
     #
-    # Span name → kind / operation.name:
-    #   "Model invoke"  → task  / chat
-    #   "Tool: <name>"  → tool  / (tool name)
-    #   "Cycle <n>"     → task  / event-loop-cycle
-    #   anything else   → agent / (agent name — the span IS the top-level agent)
+    # Span name → kind / operation.name (Strands 1.x with gen_ai_latest_experimental):
+    #   "chat"                    → task  / chat
+    #   "execute_tool <name>"     → tool  / (tool name)
+    #   "execute_event_loop_cycle"→ task  / event-loop-cycle
+    #   "invoke_agent <name>"     → agent / (agent name)
     # ============================================================================
     - id: "strands-operation"
       enabled: true
@@ -64,11 +67,11 @@ processing:
       description: "Set gen_ai.operation.kind and gen_ai.operation.name from span name"
       dql:
         script: |
-          fieldsAdd `gen_ai.operation.kind` = if(span.name == "Model invoke", "task",
-                                             else: if(startsWith(span.name, "Tool:"), "tool",
-                                             else: if(startsWith(span.name, "Cycle "), "task",
+          fieldsAdd `gen_ai.operation.kind` = if(span.name == "chat", "task",
+                                             else: if(startsWith(span.name, "execute_tool "), "tool",
+                                             else: if(span.name == "execute_event_loop_cycle", "task",
                                              else: "agent")))
-          | fieldsAdd `gen_ai.operation.name` = if(span.name == "Model invoke", "chat", else: span.name)
+          | fieldsAdd `gen_ai.operation.name` = if(span.name == "chat", "chat", else: span.name)
 
     # ============================================================================
     # 3. RESPONSE MODEL
@@ -78,7 +81,7 @@ processing:
     # ============================================================================
     - id: "strands-response-model"
       enabled: true
-      matcher: 'span.name == "Model invoke" AND isNotNull(`gen_ai.request.model`)'
+      matcher: 'span.name == "chat" AND isNotNull(`gen_ai.request.model`)'
       type: "dql"
       description: "Mirror request model to gen_ai.response.model"
       dql:
@@ -156,12 +159,12 @@ processing:
     # gen_ai.client.operation.duration (and every native SDK emitter) is in
     # SECONDS. Materialize a seconds value here and point the metric at it via
     # measurement: "field" (same fix as openpipeline-langfuse.yaml, PR #166).
-    # Scoped to Model invoke spans — the LLM call is the unit the duration and
+    # Scoped to LLM call spans (span.name == "chat" in Strands 1.x with latest semconv) — the LLM call is the unit the duration and
     # token metrics describe.
     # ============================================================================
     - id: "strands-duration-seconds"
       enabled: true
-      matcher: 'span.name == "Model invoke"'
+      matcher: 'span.name == "chat"'
       type: "dql"
       description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
       dql:
@@ -182,7 +185,7 @@ metricExtraction:
 
     - id: "strands-operation-duration-metric"
       enabled: true
-      matcher: 'span.name == "Model invoke"'
+      matcher: 'span.name == "chat"'
       type: "samplingAwareHistogramMetric"
       description: "Extract gen_ai.client.operation.duration from Strands model-invoke spans"
       samplingAwareHistogramMetric:

--- a/aws-strands/opentelemetry/otel-collector-config.yaml
+++ b/aws-strands/opentelemetry/otel-collector-config.yaml
@@ -32,6 +32,78 @@ processors:
           - delete_key(attributes, "gen_ai.usage.prompt_tokens") where attributes["gen_ai.usage.input_tokens"] != nil
           - delete_key(attributes, "gen_ai.usage.completion_tokens") where attributes["gen_ai.usage.output_tokens"] != nil
 
+  # Keep only the LLM-call spans (gen_ai.request.model is set only on "Model
+  # invoke" spans by the transform above) for the metrics branch, so the derived
+  # metrics cover LLM calls only, not the agent/tool/cycle spans. The export
+  # pipeline is left untouched so all spans still reach Distributed Tracing.
+  filter/genai_only:
+    error_mode: ignore
+    traces:
+      span:
+        - attributes["gen_ai.request.model"] == nil
+
+connectors:
+  # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
+  # from the LLM span durations — same connector the langfuse demo uses. Strands'
+  # native metrics live under strands.* names, so this recreates the semconv one.
+  spanmetrics:
+    namespace: gen_ai.client.operation
+    # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      unit: s
+      explicit:
+        buckets: [100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 30s, 60s]
+    dimensions:
+      - name: gen_ai.request.model
+      - name: gen_ai.response.model
+      - name: gen_ai.provider.name
+      - name: gen_ai.operation.name
+    metrics_flush_interval: 15s
+
+  # Token usage: Strands emits token counts as span attributes (renamed to
+  # gen_ai.usage.* above), not as the semconv metric. Re-create
+  # gen_ai.client.token.usage with two sum defs sharing one metric name; the
+  # gen_ai.token.type dimension is synthesized per direction via default_value.
+  # signaltometrics emits delta per batch, which Dynatrace requires. This needs
+  # the Bindplane collector (signaltometrics is not in the Dynatrace collector
+  # distro) — see the COLLECTOR_IMAGE in the Makefile. Collector-path equivalent
+  # of the OpenPipeline two-extractor pattern in openpipeline-strands.yaml.
+  signaltometrics:
+    include_resource_attributes:
+      - key: service.name
+    spans:
+      - name: gen_ai.client.token.usage
+        description: GenAI input token usage
+        unit: "1"
+        attributes:
+          - key: gen_ai.token.type
+            default_value: input
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+        conditions:
+          - attributes["gen_ai.usage.input_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.input_tokens"])
+          monotonic: true
+      - name: gen_ai.client.token.usage
+        description: GenAI output token usage
+        unit: "1"
+        attributes:
+          - key: gen_ai.token.type
+            default_value: output
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+        conditions:
+          - attributes["gen_ai.usage.output_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.output_tokens"])
+          monotonic: true
+
 exporters:
   otlphttp/dynatrace:
     endpoint: "${env:DT_ENDPOINT}/api/v2/otlp"
@@ -44,8 +116,15 @@ service:
       receivers: [otlp]
       processors: [transform/strands, batch]
       exporters: [otlphttp/dynatrace]
-    metrics:
+    # Second branch of the same spans: transform, keep only LLM spans, and feed
+    # the metric connectors. Kept separate from the export pipeline so the filter
+    # here never drops spans from Distributed Tracing.
+    traces/genai_metrics:
       receivers: [otlp]
+      processors: [transform/strands, filter/genai_only, batch]
+      exporters: [spanmetrics, signaltometrics]
+    metrics:
+      receivers: [otlp, spanmetrics, signaltometrics]
       processors: [batch]
       exporters: [otlphttp/dynatrace]
     logs:

--- a/aws-strands/opentelemetry/otel-collector-config.yaml
+++ b/aws-strands/opentelemetry/otel-collector-config.yaml
@@ -32,8 +32,8 @@ processors:
           - delete_key(attributes, "gen_ai.usage.prompt_tokens") where attributes["gen_ai.usage.input_tokens"] != nil
           - delete_key(attributes, "gen_ai.usage.completion_tokens") where attributes["gen_ai.usage.output_tokens"] != nil
 
-  # Keep only the LLM-call spans (gen_ai.request.model is set only on "Model
-  # invoke" spans by the transform above) for the metrics branch, so the derived
+  # Keep only the LLM-call spans ("chat" spans in Strands 1.x with gen_ai_latest_experimental;
+  # gen_ai.request.model is set only on those) for the metrics branch, so the derived
   # metrics cover LLM calls only, not the agent/tool/cycle spans. The export
   # pipeline is left untouched so all spans still reach Distributed Tracing.
   filter/genai_only:

--- a/aws-strands/opentelemetry/otel-collector-config.yaml
+++ b/aws-strands/opentelemetry/otel-collector-config.yaml
@@ -70,12 +70,14 @@ connectors:
   # distro) — see the COLLECTOR_IMAGE in the Makefile. Collector-path equivalent
   # of the OpenPipeline two-extractor pattern in openpipeline-strands.yaml.
   signaltometrics:
-    include_resource_attributes:
-      - key: service.name
     spans:
       - name: gen_ai.client.token.usage
         description: GenAI input token usage
         unit: "1"
+        # include_resource_attributes is per-metric (not a connector-level key);
+        # setting it here keeps service.name on the output metric.
+        include_resource_attributes:
+          - key: service.name
         attributes:
           - key: gen_ai.token.type
             default_value: input
@@ -91,6 +93,8 @@ connectors:
       - name: gen_ai.client.token.usage
         description: GenAI output token usage
         unit: "1"
+        include_resource_attributes:
+          - key: service.name
         attributes:
           - key: gen_ai.token.type
             default_value: output

--- a/aws-strands/opentelemetry/pyproject.toml
+++ b/aws-strands/opentelemetry/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.54b1",
     "opentelemetry-instrumentation-urllib3>=0.54b1",
     "opentelemetry-exporter-otlp-proto-http>=1.33.0",
-    "strands-agents>=1.48.0",
+    "strands-agents>=1.50.2",
     "strands-agents-tools>=0.8.5",
     "uvicorn[standard]>=0.34.0",
 ]

--- a/aws-strands/opentelemetry/uv.lock
+++ b/aws-strands/opentelemetry/uv.lock
@@ -192,7 +192,7 @@ requires-dist = [
     { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.33.0" },
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.54b1" },
     { name = "opentelemetry-instrumentation-urllib3", specifier = ">=0.54b1" },
-    { name = "strands-agents", specifier = ">=1.48.0" },
+    { name = "strands-agents", specifier = ">=1.50.2" },
     { name = "strands-agents-tools", specifier = ">=0.8.5" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
@@ -1662,12 +1662,13 @@ wheels = [
 
 [[package]]
 name = "strands-agents"
-version = "1.48.0"
+version = "1.50.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },
     { name = "docstring-parser" },
+    { name = "httpx" },
     { name = "jsonschema" },
     { name = "mcp" },
     { name = "opentelemetry-api" },
@@ -1678,9 +1679,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/1e/834e4a63c6ad039d10924b5ba8c0651ccb24d7e28fd8c07c1a09b859120f/strands_agents-1.48.0.tar.gz", hash = "sha256:bfbf5af9d8f1cb348b617d5f8d17b949ef3c3fdd74fa8c849f1fda46885449c2", size = 1174326, upload-time = "2026-07-17T14:03:45.509Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/7a/b5e20f5ee859c71e451e2e06de8767aab73d850018167c436e3a96446caf/strands_agents-1.50.2.tar.gz", hash = "sha256:7b45c41593e41f22383962a233b6616360b8c3686ae8b902059b6a6fab3deacf", size = 1224067, upload-time = "2026-07-27T20:38:48.238Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/25/67/67d1e267405f6ae119cc0412891f66997a5a97eed2dbba18fc430a9ac00a/strands_agents-1.48.0-py3-none-any.whl", hash = "sha256:7118a644e844ab6ef77f4bc9883b7082b2e7a309bcd689cc5ef5345e07abcc9e", size = 612156, upload-time = "2026-07-17T14:03:43.06Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d6/2fd27147f53c45e546c0c542c6ea4a24b93c1f3908dcbad164624e5ddfa6/strands_agents-1.50.2-py3-none-any.whl", hash = "sha256:39c6b755e579e0b631ea01af78a0a201019320670b87adcf0b5c8dd1e5a2cef8", size = 638411, upload-time = "2026-07-27T20:38:46.12Z" },
 ]
 
 [[package]]

--- a/langfuse/opentelemetry-node/README.md
+++ b/langfuse/opentelemetry-node/README.md
@@ -2,7 +2,7 @@
 
 Node.js/TypeScript demo: makes an OpenAI haiku call using the **`@langfuse/otel` SDK**,
 which emits spans with the Langfuse 4.x OTel attribute schema (`langfuse.observation.*`).
-The OTel Collector (or Dynatrace OpenPipeline) transforms those attributes to `gen_ai.*`,
+The Bindplane Collector (or Dynatrace OpenPipeline) transforms those attributes to `gen_ai.*`,
 producing the same result in Dynatrace AI Observability as the Python sibling demo.
 
 This demo mirrors [`../opentelemetry/`](../opentelemetry/) (Python) and shares the same
@@ -32,13 +32,13 @@ make run-openpipeline   # direct to Dynatrace — OpenPipeline transforms on ing
 1. `initTelemetry()` sets up `NodeSDK` with `LangfuseSpanProcessor` (from `@langfuse/otel`) backed by a custom `OTLPTraceExporter` pointing at the configured endpoint. Reads `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_EXPORTER_OTLP_HEADERS` from env.
 2. `propagateAttributes({ sessionId })` sets `session.id` in OTel baggage so all child spans inherit it.
 3. `observeOpenAI` (from `@langfuse/openai`) wraps the OpenAI client and automatically emits a generation span with `langfuse.observation.*` attributes: model, temperature, input messages, output messages, and token usage.
-4. The OTel Collector (or Dynatrace OpenPipeline) transforms `langfuse.*` → `gen_ai.*`.
+4. The Bindplane Collector (or Dynatrace OpenPipeline) transforms `langfuse.*` → `gen_ai.*`.
 5. Spans appear in Dynatrace AI Observability with model name, token usage, and latency.
 
 ### Collector path (`make run`)
 
 ```
-Node.js app → OTLP → OTel Collector → (transform) → Dynatrace
+Node.js app → OTLP → Bindplane Collector → (transform) → Dynatrace
 ```
 
 Collector config: `../opentelemetry/otel-collector-config.yaml`. A `spanmetrics` connector in that config derives `gen_ai.client.operation.duration` from the LLM span durations, and a `signal_to_metrics` connector derives `gen_ai.client.token.usage` from `gen_ai.usage.input_tokens` / `output_tokens` — both exported to Dynatrace (needs the token's `metrics.ingest` scope). The OpenPipeline path produces the same two metrics server-side via metric-extraction processors.

--- a/langfuse/opentelemetry/README.md
+++ b/langfuse/opentelemetry/README.md
@@ -11,7 +11,7 @@ Langfuse uses its own semantic conventions (`langfuse.observation.type`, `langfu
 - [Prerequisites](#prerequisites)
 - [Configuration options](#configuration-options)
 - [Setup](#setup)
-- [Option A -- OTel Collector with transform processor](#option-a----otel-collector-with-transform-processor)
+- [Option A -- Bindplane Collector with transform processor](#option-a----bindplane-collector-with-transform-processor)
 - [Option B -- Dynatrace OpenPipeline](#option-b----dynatrace-openpipeline)
 - [Visualize in Dynatrace AI Observability](#visualize-in-dynatrace-ai-observability)
 - [Attribute mapping reference](#attribute-mapping-reference)
@@ -23,7 +23,7 @@ Langfuse uses its own semantic conventions (`langfuse.observation.type`, `langfu
 
 - Calls an LLM to generate a haiku using the Langfuse instrumentation library.
 - Produces OpenTelemetry traces with Langfuse SDK 4.x semantic conventions (`langfuse.observation.*` attributes).
-- Normalizes Langfuse attributes to Dynatrace `gen_ai.*` format -- either via a local OTel Collector or via Dynatrace OpenPipeline.
+- Normalizes Langfuse attributes to Dynatrace `gen_ai.*` format -- either via a local Bindplane Collector or via Dynatrace OpenPipeline.
 - Shows the trace in the Dynatrace AI Observability app with model, token usage, conversation grouping, and message content.
 
 ---
@@ -42,7 +42,7 @@ Langfuse uses its own semantic conventions (`langfuse.observation.type`, `langfu
 
 Langfuse uses its own semantic conventions that the Dynatrace AI Observability app does not natively understand. Two equivalent approaches normalize the attributes:
 
-|  | Option A -- OTel Collector | Option B -- OpenPipeline |
+|  | Option A -- Bindplane Collector | Option B -- OpenPipeline |
 |---|---|---|
 | **Where transforms run** | In the collector process | Server-side, in your Dynatrace tenant |
 | **Requires Docker** | Yes | No |
@@ -93,12 +93,12 @@ make install
 
 ---
 
-## Option A -- OTel Collector with transform processor
+## Option A -- Bindplane Collector with transform processor
 
-The OTel Collector intercepts spans and applies all Langfuse → `gen_ai.*` attribute mappings before forwarding to Dynatrace. No Dynatrace configuration needed.
+The Bindplane Collector intercepts spans and applies all Langfuse → `gen_ai.*` attribute mappings before forwarding to Dynatrace. No Dynatrace configuration needed.
 
 ```
-App  →  Langfuse SDK (OTLP export)  →  OTel Collector (transform processor)  →  Dynatrace Grail
+App  →  Langfuse SDK (OTLP export)  →  Bindplane Collector (transform processor)  →  Dynatrace Grail
 ```
 
 ```bash
@@ -161,7 +161,7 @@ make run-openpipeline
 
 ## Attribute mapping reference
 
-These mappings are applied by both the OTel Collector (`transform/langfuse` processor) and Dynatrace OpenPipeline. Langfuse SDK 4.x attribute names are used.
+These mappings are applied by both the Bindplane Collector (`transform/langfuse` processor) and Dynatrace OpenPipeline. Langfuse SDK 4.x attribute names are used.
 
 | Langfuse source | Dynatrace target | Notes |
 |---|---|---|

--- a/openai/openinference/Makefile
+++ b/openai/openinference/Makefile
@@ -12,10 +12,10 @@ DT_API_TOKEN        ?= dt0c01.*****
 APP_IMAGE           ?=
 BUILD_PLATFORM      ?= linux/amd64
 
-# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.104.0 tracks OTel
-# contrib v0.156.0 and bundles genainormalizerprocessor. Pinned so a version
-# bump surfaces normalization regressions in the e2e test.
-override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.104.0
+# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.105.0 tracks OTel
+# contrib v0.157.0 and bundles genainormalizerprocessor + signal_to_metrics
+# connector. Pinned so a version bump surfaces normalization regressions in the e2e test.
+override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.105.0
 override COLLECTOR_CONTAINER := bindplane-otel-collector
 
 .PHONY: run run-openpipeline build push request stop logs install help

--- a/openai/openinference/README.md
+++ b/openai/openinference/README.md
@@ -17,6 +17,7 @@ OpenInference uses its own semantic conventions (`llm.model_name`, `llm.token_co
 - [Option B -- Dynatrace OpenPipeline](#option-b----dynatrace-openpipeline)
 - [Visualize in Dynatrace AI Observability](#visualize-in-dynatrace-ai-observability)
 - [Attribute mapping reference](#attribute-mapping-reference)
+- [Metrics](#metrics)
 - [Known gaps & limitations](#known-gaps--limitations)
 - [Troubleshooting](#troubleshooting)
 
@@ -252,6 +253,19 @@ Unlike a hand-written transform, `genainormalizer` reconstructs the full convers
 The OpenPipeline configuration in [`openpipeline-openinference.yaml`](openpipeline-openinference.yaml) applies its own DQL-based translations server-side, including `gen_ai.operation.kind`, request parameters (`temperature`, `max_tokens`, `top_p`), `finish_reasons`, and prompt-caching flags. It uses an interim fallback for message content (`input.value` / `output.value` → `gen_ai.input.messages` / `gen_ai.output.messages`) because DQL cannot iterate over the indexed per-message attributes at transform time.
 
 `session.id` and `user.id` already match the OTel standard and pass through unchanged in both options.
+
+---
+
+## Metrics
+
+OpenInference is span-only by design (its instrumentors emit no metric instruments), so the two metrics the AI Observability app charts must be derived from the spans. Both options do this, so the cost and latency tiles populate either way:
+
+| Metric | Option A (collector) | Option B (OpenPipeline) |
+|---|---|---|
+| `gen_ai.client.operation.duration` (s) | `spanmetrics` connector, on LLM spans | `samplingAwareHistogramMetric` extractor on `duration_seconds` |
+| `gen_ai.client.token.usage` (`gen_ai.token.type` = `input`/`output`) | `signaltometrics` connector, two sum defs | two `samplingAwareValueMetric` extractors, one per direction |
+
+Both read the normalized `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` (mapped from OpenInference's `llm.token_count.*`). **Option A** derives both metrics in the Bindplane collector — `signaltometrics` (token) is bundled there alongside `genainormalizer`; requires the token's `metrics.ingest` scope, and both metrics use delta temporality (Dynatrace rejects cumulative). **Option B** derives the same two metrics server-side via the metric-extraction processors in [`openpipeline-openinference.yaml`](openpipeline-openinference.yaml); the token metric uses the two-extractor pattern (one per direction, both writing `gen_ai.client.token.usage` with a constant `gen_ai.token.type` dimension).
 
 ---
 

--- a/openai/openinference/openpipeline-openinference.yaml
+++ b/openai/openinference/openpipeline-openinference.yaml
@@ -495,3 +495,120 @@ processing:
             `llm.input_messages.0.message.role` == "system",
             `llm.input_messages.0.message.content`
           )
+
+    # ============================================================================
+    # 17. DURATION IN SECONDS (feeds the operation-duration metric below)
+    # ============================================================================
+    # The span `duration` field is in nanoseconds. The metric-extraction
+    # "duration" measurement emits MICROSECONDS, but the OTel semconv metric
+    # gen_ai.client.operation.duration (and every native SDK emitter) is in
+    # SECONDS. Materialize a seconds value here and point the metric at it via
+    # measurement: "field" (same fix as openpipeline-langfuse.yaml, PR #166).
+    # Scoped to LLM spans — the same spans that carry gen_ai.usage.* tokens.
+    # ============================================================================
+    - id: "openinference-duration-seconds"
+      enabled: true
+      matcher: "isNotNull(`gen_ai.usage.input_tokens`) OR isNotNull(`gen_ai.usage.output_tokens`)"
+      type: "dql"
+      description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
+      dql:
+        script: |
+          fieldsAdd duration_seconds = toDouble(duration) / 1000000000.0
+
+# ==============================================================================
+# METRIC EXTRACTION
+# ==============================================================================
+# OpenInference is span-only by design (_supports_metrics=False), so neither
+# gen_ai.client.operation.duration nor gen_ai.client.token.usage is emitted
+# natively. Both are re-created here from the attributes normalized above, the
+# same tenant-side two-extractor pattern used for OneAgent
+# (openpipeline/openpipeline-oneagent-genai-metrics.yaml). Token attributes were
+# renamed from llm.token_count.* to gen_ai.usage.* in processor 5; response.model
+# was set in processor 6.
+# ==============================================================================
+metricExtraction:
+  processors:
+
+    - id: "openinference-operation-duration-metric"
+      enabled: true
+      matcher: "isNotNull(duration_seconds)"
+      type: "samplingAwareHistogramMetric"
+      description: "Extract gen_ai.client.operation.duration from OpenInference LLM spans"
+      samplingAwareHistogramMetric:
+        metricKey: "gen_ai.client.operation.duration"
+        measurement: "field"
+        field: "duration_seconds"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    # ============================================================================
+    # TOKEN USAGE — two extractors, same metric key, aliased dimension
+    # ============================================================================
+    # A span carries gen_ai.usage.input_tokens and gen_ai.usage.output_tokens as
+    # two separate numeric fields with no token-type dimension of their own. The
+    # app queries one dimensioned metric (`sum(gen_ai.client.token.usage)` filtered
+    # by `gen_ai.token.type`), so each direction gets its own extractor into the
+    # same metricKey, with a constant dimension value naming which one it is.
+    # ============================================================================
+    - id: "openinference-token-usage-input-metric"
+      enabled: true
+      matcher: "isNotNull(`gen_ai.usage.input_tokens`)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (input tokens) from OpenInference spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.input_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "input"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"
+
+    - id: "openinference-token-usage-output-metric"
+      enabled: true
+      matcher: "isNotNull(`gen_ai.usage.output_tokens`)"
+      type: "samplingAwareValueMetric"
+      description: "Extract gen_ai.client.token.usage (output tokens) from OpenInference spans"
+      samplingAwareValueMetric:
+        metricKey: "gen_ai.client.token.usage"
+        measurement: "field"
+        field: "gen_ai.usage.output_tokens"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "constant"
+            constantFieldName: "gen_ai.token.type"
+            constantValue: "output"
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -61,18 +61,19 @@ connectors:
   # counts live only as span attributes. Re-create gen_ai.client.token.usage from
   # them with two sum defs sharing one metric name; the gen_ai.token.type dimension
   # is synthesized per direction via default_value (the span carries no such
-  # attribute). signaltometrics emits delta per batch, which Dynatrace requires.
+  # attribute). signal_to_metrics emits delta per batch, which Dynatrace requires.
   # (This is the collector-path equivalent of the OpenPipeline two-extractor
   # pattern in openpipeline-openinference.yaml.)
-  signaltometrics:
+  signal_to_metrics:
     spans:
       - name: gen_ai.client.token.usage
-        description: GenAI input token usage
-        unit: "1"
-        # include_resource_attributes is per-metric (not a connector-level key);
-        # setting it here keeps service.name on the output metric.
-        include_resource_attributes:
-          - key: service.name
+        description: "Number of tokens used per LLM call, by direction"
+        unit: "{token}"
+        conditions:
+          - attributes["gen_ai.usage.input_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.input_tokens"])
+          monotonic: true
         attributes:
           - key: gen_ai.token.type
             default_value: input
@@ -80,16 +81,14 @@ connectors:
           - key: gen_ai.response.model
           - key: gen_ai.provider.name
           - key: gen_ai.operation.name
-        conditions:
-          - attributes["gen_ai.usage.input_tokens"] != nil
-        sum:
-          value: Int(attributes["gen_ai.usage.input_tokens"])
-          monotonic: true
       - name: gen_ai.client.token.usage
-        description: GenAI output token usage
-        unit: "1"
-        include_resource_attributes:
-          - key: service.name
+        description: "Number of tokens used per LLM call, by direction"
+        unit: "{token}"
+        conditions:
+          - attributes["gen_ai.usage.output_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.output_tokens"])
+          monotonic: true
         attributes:
           - key: gen_ai.token.type
             default_value: output
@@ -97,11 +96,8 @@ connectors:
           - key: gen_ai.response.model
           - key: gen_ai.provider.name
           - key: gen_ai.operation.name
-        conditions:
-          - attributes["gen_ai.usage.output_tokens"] != nil
-        sum:
-          value: Int(attributes["gen_ai.usage.output_tokens"])
-          monotonic: true
+      # service.name is a resource attribute included by default — no
+      # include_resource_attributes filter needed, same as spanmetrics.
 
 exporters:
   debug:
@@ -123,7 +119,7 @@ service:
     traces/genai_metrics:
       receivers: [otlp]
       processors: [gen_ai_normalizer, transform/response_model, filter/genai_only]
-      exporters: [spanmetrics, signaltometrics]
+      exporters: [spanmetrics, signal_to_metrics]
     metrics:
-      receivers: [spanmetrics, signaltometrics]
+      receivers: [spanmetrics, signal_to_metrics]
       exporters: [otlp_http/dynatrace]

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -65,12 +65,14 @@ connectors:
   # (This is the collector-path equivalent of the OpenPipeline two-extractor
   # pattern in openpipeline-openinference.yaml.)
   signaltometrics:
-    include_resource_attributes:
-      - key: service.name
     spans:
       - name: gen_ai.client.token.usage
         description: GenAI input token usage
         unit: "1"
+        # include_resource_attributes is per-metric (not a connector-level key);
+        # setting it here keeps service.name on the output metric.
+        include_resource_attributes:
+          - key: service.name
         attributes:
           - key: gen_ai.token.type
             default_value: input
@@ -86,6 +88,8 @@ connectors:
       - name: gen_ai.client.token.usage
         description: GenAI output token usage
         unit: "1"
+        include_resource_attributes:
+          - key: service.name
         attributes:
           - key: gen_ai.token.type
             default_value: output

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -27,6 +27,78 @@ processors:
         statements:
           - set(attributes["gen_ai.response.model"], attributes["gen_ai.request.model"]) where attributes["gen_ai.request.model"] != nil and attributes["gen_ai.response.model"] == nil
 
+  # Keep only spans that represent an LLM call (gen_ai.request.model is set by the
+  # normalizer on LLM spans). Feeds the metrics connectors so the derived metrics
+  # cover LLM calls only, not embedding/tool/chain spans. Used solely on the
+  # metrics branch — the export pipeline is left untouched so all spans still
+  # reach Distributed Tracing.
+  filter/genai_only:
+    error_mode: ignore
+    traces:
+      span:
+        - attributes["gen_ai.request.model"] == nil
+
+connectors:
+  # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
+  # from the LLM span durations — same connector the langfuse demo uses. namespace +
+  # the connector's "duration" histogram => gen_ai.client.operation.duration.
+  spanmetrics:
+    namespace: gen_ai.client.operation
+    # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      unit: s
+      explicit:
+        buckets: [100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 30s, 60s]
+    dimensions:
+      - name: gen_ai.request.model
+      - name: gen_ai.response.model
+      - name: gen_ai.provider.name
+      - name: gen_ai.operation.name
+    metrics_flush_interval: 15s
+
+  # Token usage: OpenInference is span-only (no metric instruments), so the token
+  # counts live only as span attributes. Re-create gen_ai.client.token.usage from
+  # them with two sum defs sharing one metric name; the gen_ai.token.type dimension
+  # is synthesized per direction via default_value (the span carries no such
+  # attribute). signaltometrics emits delta per batch, which Dynatrace requires.
+  # (This is the collector-path equivalent of the OpenPipeline two-extractor
+  # pattern in openpipeline-openinference.yaml.)
+  signaltometrics:
+    include_resource_attributes:
+      - key: service.name
+    spans:
+      - name: gen_ai.client.token.usage
+        description: GenAI input token usage
+        unit: "1"
+        attributes:
+          - key: gen_ai.token.type
+            default_value: input
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+        conditions:
+          - attributes["gen_ai.usage.input_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.input_tokens"])
+          monotonic: true
+      - name: gen_ai.client.token.usage
+        description: GenAI output token usage
+        unit: "1"
+        attributes:
+          - key: gen_ai.token.type
+            default_value: output
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+        conditions:
+          - attributes["gen_ai.usage.output_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.output_tokens"])
+          monotonic: true
+
 exporters:
   debug:
     verbosity: detailed
@@ -41,3 +113,13 @@ service:
       receivers: [otlp]
       processors: [gen_ai_normalizer, transform/response_model]
       exporters: [debug, otlp_http/dynatrace]
+    # Second branch of the same spans: normalize, keep only LLM spans, and feed
+    # the metric connectors. Kept separate from the export pipeline so the filter
+    # here never drops spans from Distributed Tracing.
+    traces/genai_metrics:
+      receivers: [otlp]
+      processors: [gen_ai_normalizer, transform/response_model, filter/genai_only]
+      exporters: [spanmetrics, signaltometrics]
+    metrics:
+      receivers: [spanmetrics, signaltometrics]
+      exporters: [otlp_http/dynatrace]

--- a/pydantic-ai/opentelemetry/Makefile
+++ b/pydantic-ai/opentelemetry/Makefile
@@ -4,7 +4,16 @@ export
 
 PORT             ?= 8000
 
-.PHONY: install run build push request help
+DT_ENDPOINT      ?= https://your-tenant.live.dynatrace.com
+DT_API_TOKEN     ?= dt0c01.*****
+
+# Bindplane Distro for OpenTelemetry (BDOT) collector. v1.104.0 tracks OTel
+# contrib v0.156.0. Used only by `make run-collector` to derive
+# gen_ai.client.operation.duration from spans via the spanmetrics connector.
+override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.104.0
+override COLLECTOR_CONTAINER := otel-collector
+
+.PHONY: install run run-collector build push request stop logs help
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
@@ -12,8 +21,46 @@ help: ## Show available targets
 install: ## Install Python dependencies
 	uv sync
 
-run: ## Run the Pydantic AI backend on port $(PORT)
+run: ## Run the backend, exporting straight to Dynatrace [needs OpenPipeline for duration]
 	PYTHONPATH=backend uv run python3 -m uvicorn backend.main:app --host 0.0.0.0 --port $(PORT)
+
+run-collector: ## Start the OTel Collector, then run the backend exporting through it
+	@$(MAKE) _collector CONFIG=otel-collector-config.yaml
+	OTEL_COLLECTOR_ENDPOINT=http://localhost:4318 \
+	  PYTHONPATH=backend uv run python3 -m uvicorn backend.main:app --host 0.0.0.0 --port $(PORT)
+
+stop: ## Stop and remove the OTel collector container
+	docker stop $(COLLECTOR_CONTAINER) && docker rm $(COLLECTOR_CONTAINER)
+
+logs: ## Tail collector logs
+	@touch collector.log && tail -F collector.log
+
+_collector:
+	@if docker ps --filter name=$(COLLECTOR_CONTAINER) --filter status=running -q | grep -q .; then \
+	  echo "Collector already running — stopping it first..."; \
+	  docker stop $(COLLECTOR_CONTAINER) && docker rm $(COLLECTOR_CONTAINER); \
+	fi; \
+	echo "Starting collector ($(CONFIG)) -> $(DT_ENDPOINT)" && \
+	docker run -d \
+	  --name $(COLLECTOR_CONTAINER) \
+	  -p 4318:4318 \
+	  -v $$(pwd)/$(CONFIG):/etc/otel/config.yaml:ro \
+	  -e DT_ENDPOINT=$(DT_ENDPOINT) \
+	  -e DT_API_TOKEN=$(DT_API_TOKEN) \
+	  $(COLLECTOR_IMAGE) && \
+	docker logs -f $(COLLECTOR_CONTAINER) > collector.log 2>&1 & \
+	echo "Collector logs -> collector.log" && \
+	for i in $$(seq 1 15); do \
+	  if docker ps --filter name=$(COLLECTOR_CONTAINER) --filter status=running -q | grep -q .; then \
+	    echo "Collector is up"; exit 0; \
+	  fi; \
+	  STATUS=$$(docker inspect -f '{{.State.Status}}' $(COLLECTOR_CONTAINER) 2>/dev/null); \
+	  if [ "$$STATUS" = "exited" ]; then \
+	    echo "ERROR: collector crashed — logs:"; docker logs $(COLLECTOR_CONTAINER); exit 1; \
+	  fi; \
+	  echo "  ... ($$i/15)"; sleep 2; \
+	done; \
+	echo "ERROR: collector did not become ready"; docker logs $(COLLECTOR_CONTAINER); exit 1
 
 build: ## Not applicable — no container defined for this demo
 	@echo "build: no Dockerfile for this demo"

--- a/pydantic-ai/opentelemetry/backend/otel_setup.py
+++ b/pydantic-ai/opentelemetry/backend/otel_setup.py
@@ -11,15 +11,31 @@ def setup_otel(service_name: str = "pydantic-ai-music-agent"):
     Returns (tracer_provider, meter_provider) so callers can pass them into
     pydantic-ai's InstrumentationSettings.
     """
-    dt_endpoint = os.environ.get("DT_ENDPOINT", "").rstrip("/")
-    dt_api_token = os.environ.get("DT_API_TOKEN", "")
+    # Two export paths:
+    #  - Direct (default): spans + metrics go straight to Dynatrace OTLP. pydantic-ai
+    #    emits gen_ai.client.token.usage natively, but NOT operation.duration, so the
+    #    duration metric must be backfilled server-side (openpipeline-pydantic-ai.yaml).
+    #  - Collector: set OTEL_COLLECTOR_ENDPOINT (e.g. http://localhost:4318) to route
+    #    through the local OTel Collector, which derives gen_ai.client.operation.duration
+    #    from the LLM spans (spanmetrics) and forwards everything to Dynatrace. The
+    #    collector holds the DT token, so no Authorization header is sent from the app.
+    collector_endpoint = os.environ.get("OTEL_COLLECTOR_ENDPOINT", "").rstrip("/")
 
-    if not dt_endpoint or not dt_api_token:
-        print("[otel] DT-ENDPOINT or DT-TOKEN not set — OTel export disabled")
-        return None, None
+    if collector_endpoint:
+        otlp_base = collector_endpoint
+        headers = {}
+        target = f"collector {collector_endpoint}"
+    else:
+        dt_endpoint = os.environ.get("DT_ENDPOINT", "").rstrip("/")
+        dt_api_token = os.environ.get("DT_API_TOKEN", "")
 
-    otlp_base = f"{dt_endpoint}/api/v2/otlp"
-    headers = {"Authorization": f"Api-Token {dt_api_token}"}
+        if not dt_endpoint or not dt_api_token:
+            print("[otel] DT-ENDPOINT or DT-TOKEN not set — OTel export disabled")
+            return None, None
+
+        otlp_base = f"{dt_endpoint}/api/v2/otlp"
+        headers = {"Authorization": f"Api-Token {dt_api_token}"}
+        target = otlp_base
 
     # Dynatrace requires delta temporality for metrics
     os.environ["OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE"] = "delta"
@@ -59,5 +75,5 @@ def setup_otel(service_name: str = "pydantic-ai-music-agent"):
     )
     metrics.set_meter_provider(meter_provider)
 
-    print(f"[otel] Exporting to {otlp_base}")
+    print(f"[otel] Exporting to {target}")
     return tracer_provider, meter_provider

--- a/pydantic-ai/opentelemetry/backend/otel_setup.py
+++ b/pydantic-ai/opentelemetry/backend/otel_setup.py
@@ -54,6 +54,7 @@ def setup_otel(service_name: str = "pydantic-ai-music-agent"):
             "service.name": service_name,
             "service.version": "0.1.0",
             "gen_ai.agent.name": service_name,
+            "telemetry.sdk.name": "pydantic-ai",
         }
     )
 

--- a/pydantic-ai/opentelemetry/openpipeline-pydantic-ai.yaml
+++ b/pydantic-ai/opentelemetry/openpipeline-pydantic-ai.yaml
@@ -1,0 +1,78 @@
+---
+# OpenPipeline configuration for the pydantic-ai music-agent demo.
+#
+# pydantic-ai exports gen_ai.* spans (and the gen_ai.client.token.usage metric)
+# straight to Dynatrace OTLP with no collector in between. Token usage arrives
+# natively, but pydantic-ai does NOT emit gen_ai.client.operation.duration — so
+# the AI Observability app's latency tiles stay empty. That one metric is
+# backfilled here tenant-side from the span duration, the same duration
+# extraction used for OneAgent
+# (openpipeline/openpipeline-oneagent-genai-metrics.yaml). No token extractor is
+# needed — pydantic-ai already emits gen_ai.client.token.usage.
+#
+# Deploy this pipeline in your Dynatrace tenant (Settings -> OpenPipeline -> Spans),
+# then add a routing entry:
+#   Matcher:  isNotNull(gen_ai.response.model)
+#   Pipeline: pydantic-ai-genai-metrics
+#
+# Scope note: pydantic-ai adds nested GenAI spans for each model call — those
+# carry gen_ai.response.model and are the correct unit for operation.duration.
+# The demo's outer "music_agent.ask" SERVER span sets only gen_ai.request.model
+# (never response.model), so keying on response.model targets the LLM span alone
+# and avoids double-counting the API-level wrapper span (which also spans retries).
+
+customId: "pydantic-ai-genai-metrics"
+displayName: "pydantic-ai AI Observability - Metrics"
+
+processing:
+  processors:
+
+    # ============================================================================
+    # DURATION IN SECONDS (feeds the operation-duration metric below)
+    # ============================================================================
+    # The span `duration` field is in nanoseconds. The metric-extraction
+    # "duration" measurement emits MICROSECONDS, but the OTel semconv metric
+    # gen_ai.client.operation.duration (and every native SDK emitter) is in
+    # SECONDS. Materialize a seconds value here and point the metric at it via
+    # measurement: "field" (same fix as openpipeline-langfuse.yaml, PR #166).
+    # ============================================================================
+    - id: "pydantic-ai-duration-seconds"
+      enabled: true
+      matcher: "isNotNull(`gen_ai.response.model`)"
+      type: "dql"
+      description: "Compute LLM call duration in seconds (span duration is nanoseconds)"
+      dql:
+        script: |
+          fieldsAdd duration_seconds = toDouble(duration) / 1000000000.0
+
+# ==============================================================================
+# METRIC EXTRACTION
+# ==============================================================================
+# Only gen_ai.client.operation.duration is backfilled — pydantic-ai emits
+# gen_ai.client.token.usage natively.
+# ==============================================================================
+metricExtraction:
+  processors:
+
+    - id: "pydantic-ai-operation-duration-metric"
+      enabled: true
+      matcher: "isNotNull(duration_seconds)"
+      type: "samplingAwareHistogramMetric"
+      description: "Extract gen_ai.client.operation.duration from pydantic-ai LLM spans"
+      samplingAwareHistogramMetric:
+        metricKey: "gen_ai.client.operation.duration"
+        measurement: "field"
+        field: "duration_seconds"
+        aggregation: "enabled"
+        sampling: "enabled"
+        dimensions:
+          - extractionType: "field"
+            sourceFieldName: "service.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.operation.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.provider.name"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.request.model"
+          - extractionType: "field"
+            sourceFieldName: "gen_ai.response.model"

--- a/pydantic-ai/opentelemetry/openpipeline-pydantic-ai.yaml
+++ b/pydantic-ai/opentelemetry/openpipeline-pydantic-ai.yaml
@@ -12,7 +12,7 @@
 #
 # Deploy this pipeline in your Dynatrace tenant (Settings -> OpenPipeline -> Spans),
 # then add a routing entry:
-#   Matcher:  isNotNull(gen_ai.response.model)
+#   Matcher:  telemetry.sdk.name == "pydantic-ai"
 #   Pipeline: pydantic-ai-genai-metrics
 #
 # Scope note: pydantic-ai adds nested GenAI spans for each model call — those

--- a/pydantic-ai/opentelemetry/otel-collector-config.yaml
+++ b/pydantic-ai/opentelemetry/otel-collector-config.yaml
@@ -1,0 +1,66 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+    send_batch_size: 512
+    timeout: 5s
+
+  # Keep only the nested LLM-call spans for the metrics branch. pydantic-ai sets
+  # gen_ai.response.model on the model-call spans; the demo's outer
+  # "music_agent.ask" wrapper span sets only gen_ai.request.model. Keying on
+  # response.model targets the LLM call alone, so spanmetrics does not also derive
+  # a (wrong, retry-spanning) duration from the wrapper span. The export pipeline
+  # is untouched, so all spans still reach Distributed Tracing.
+  filter/genai_only:
+    error_mode: ignore
+    traces:
+      span:
+        - attributes["gen_ai.response.model"] == nil
+
+connectors:
+  # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
+  # from the LLM span durations — pydantic-ai emits the token metric natively but
+  # NOT this one. Same connector the langfuse demo uses.
+  spanmetrics:
+    namespace: gen_ai.client.operation
+    # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      unit: s
+      explicit:
+        buckets: [100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 30s, 60s]
+    dimensions:
+      - name: gen_ai.request.model
+      - name: gen_ai.response.model
+      - name: gen_ai.provider.name
+      - name: gen_ai.operation.name
+    metrics_flush_interval: 15s
+
+exporters:
+  debug:
+    verbosity: detailed
+  otlp_http/dynatrace:
+    endpoint: ${env:DT_ENDPOINT}/api/v2/otlp
+    headers:
+      Authorization: "Api-Token ${env:DT_API_TOKEN}"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug, otlp_http/dynatrace]
+    # Second branch: keep only LLM spans and feed the spanmetrics connector.
+    traces/genai_metrics:
+      receivers: [otlp]
+      processors: [filter/genai_only, batch]
+      exporters: [spanmetrics]
+    # pydantic-ai's native gen_ai.client.token.usage arrives on [otlp]; the derived
+    # gen_ai.client.operation.duration arrives on [spanmetrics]. Both forwarded.
+    metrics:
+      receivers: [otlp, spanmetrics]
+      exporters: [otlp_http/dynatrace]

--- a/test/e2e/aws_bedrock_openinference_test.go
+++ b/test/e2e/aws_bedrock_openinference_test.go
@@ -15,18 +15,19 @@ func TestAWSBedrockOpenInference(t *testing.T) {
 	// unspecified, and the guardrail-blocked trace is missing several
 	// baseline attributes (e.g. token usage), which would flip this audit's
 	// verdict independent of any real regression.
-	auditSpan(t, "aws-bedrock", "openinference", GenericProfile,
+	auditSpanWithMetrics(t, "aws-bedrock", "openinference", GenericProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock/openinference"
 | filter isNotNull(gen_ai.request.model)
 | filter isNull(span.status_code) or span.status_code != "error"
 | sort start_time asc
-| limit 1`)
+| limit 1`,
+		"aws-bedrock/openinference", genAIClientMetrics)
 
 	// The guardrail-triggering request is always sent last, so the latest
 	// matching span is the one that actually tripped the guardrail. Metrics are
 	// service-scoped and include data from the non-guardrail request above.
-	auditSpanOptionalWithMetrics(t, "aws-bedrock", "openinference-guardrail", GuardrailProfile,
+	auditSpanWithMetrics(t, "aws-bedrock", "openinference-guardrail", GuardrailProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock/openinference"
 | filter isNotNull(gen_ai.request.model)

--- a/test/e2e/aws_bedrock_openinference_test.go
+++ b/test/e2e/aws_bedrock_openinference_test.go
@@ -24,11 +24,13 @@ func TestAWSBedrockOpenInference(t *testing.T) {
 | limit 1`)
 
 	// The guardrail-triggering request is always sent last, so the latest
-	// matching span is the one that actually tripped the guardrail.
-	auditGuardrailSpan(t, "aws-bedrock", "openinference",
+	// matching span is the one that actually tripped the guardrail. Metrics are
+	// service-scoped and include data from the non-guardrail request above.
+	auditSpanOptionalWithMetrics(t, "aws-bedrock", "openinference-guardrail", GuardrailProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock/openinference"
 | filter isNotNull(gen_ai.request.model)
 | sort start_time desc
-| limit 1`)
+| limit 1`,
+		"aws-bedrock/openinference", genAIClientMetrics)
 }

--- a/test/e2e/aws_strands_opentelemetry_openpipeline_test.go
+++ b/test/e2e/aws_strands_opentelemetry_openpipeline_test.go
@@ -11,11 +11,14 @@ func TestAWSStrandsOpenTelemetryOpenPipeline(t *testing.T) {
 
 	// gen_ai.bedrock.guardrail.* (AR-017/AR-018/AR-019) are not emitted
 	// because the demo does not configure Bedrock guardrails — expected FAIL in report.
-	auditSpan(t, "aws-strands", "opentelemetry-openpipeline", BedrockProfile,
+	// Metrics are derived server-side by the OpenPipeline strands-agents-ai-spans
+	// pipeline (metric extraction added in this branch).
+	auditSpanWithMetrics(t, "aws-strands", "opentelemetry-openpipeline", BedrockProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-strands/opentelemetry-openpipeline"
 | filter isNotNull(gen_ai.provider.name)
 | filter isNotNull(gen_ai.request.model)
 | sort timestamp desc
-| limit 1`)
+| limit 1`,
+		"aws-strands/opentelemetry-openpipeline", genAIClientMetrics)
 }

--- a/test/e2e/aws_strands_opentelemetry_test.go
+++ b/test/e2e/aws_strands_opentelemetry_test.go
@@ -9,11 +9,16 @@ func TestAWSStrandsOpenTelemetry(t *testing.T) {
 
 	// gen_ai.bedrock.guardrail.* (AR-017/AR-018/AR-019) are not emitted
 	// because the demo does not configure Bedrock guardrails — expected FAIL in report.
-	auditSpan(t, "aws-strands", "opentelemetry", BedrockProfile,
+	// The otel-collector derives gen_ai.client.token.usage and
+	// gen_ai.client.operation.duration from span attributes/durations via the
+	// signaltometrics and spanmetrics connectors; results are recorded alongside
+	// the span audit in the generated report.
+	auditSpanWithMetrics(t, "aws-strands", "opentelemetry", BedrockProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-strands/opentelemetry"
 | filter isNotNull(gen_ai.provider.name)
 | filter isNotNull(gen_ai.request.model)
 | sort timestamp desc
-| limit 1`)
+| limit 1`,
+		"aws-strands/opentelemetry", genAIClientMetrics)
 }

--- a/test/e2e/fixture_metrics_test.go
+++ b/test/e2e/fixture_metrics_test.go
@@ -73,3 +73,39 @@ func auditSpanWithMetrics(t *testing.T, sdk, instrumentation string, p Profile, 
 	writeReport(t, report)
 	logAuditResult(t, report, spanCount)
 }
+
+// auditSpanOptionalWithMetrics is like auditSpanWithMetrics but skips the
+// (sub)test when no anchor span is found within the timeout instead of failing.
+// Use for provider-specific audits where the provider may not have been
+// selected in the current run.
+func auditSpanOptionalWithMetrics(t *testing.T, sdk, instrumentation string, p Profile, dql, serviceName string, metricKeys []string, note ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), spanPollTimeout())
+	defer cancel()
+
+	records, err := dtClient.PollUntilSpans(ctx, scopedDQL(dql), 15*time.Second)
+	if err != nil || len(records) == 0 {
+		t.Skipf("no %s/%s spans found — provider likely not selected this run", sdk, instrumentation)
+		return
+	}
+	assertNotErrorSpan(t, records[0])
+
+	spans := fetchTraceSpans(t, ctx, records[0])
+	report := buildReport(sdk, instrumentation, p, mergeSpans(spans))
+	if len(note) > 0 {
+		report.Note = note[0]
+	}
+
+	for _, key := range metricKeys {
+		status := "absent"
+		if pollMetricExists(t, serviceName, key) {
+			status = "present"
+		} else {
+			t.Errorf("metric %q not found for service %q within timeout", key, serviceName)
+		}
+		report.Metrics = append(report.Metrics, MetricResult{Metric: key, Status: status})
+	}
+
+	writeReport(t, report)
+	logAuditResult(t, report, len(spans))
+}

--- a/test/e2e/openai_openinference_test.go
+++ b/test/e2e/openai_openinference_test.go
@@ -9,11 +9,12 @@ func TestOpenAIOpenInference(t *testing.T) {
 	// No triggerHaiku — the haiku request is issued by make run itself.
 	startCLIApp(t, "openai/openinference")
 
-	auditSpan(t, "openai", "openinference", OpenAIProfile,
+	auditSpanWithMetrics(t, "openai", "openinference", OpenAIProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "openai/openinference"
 | filter isNotNull(gen_ai.request.model)
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+		"pydantic-ai-music-agent", genAIClientMetrics)
 }

--- a/test/e2e/pydantic_ai_opentelemetry_test.go
+++ b/test/e2e/pydantic_ai_opentelemetry_test.go
@@ -12,21 +12,23 @@ func TestPydanticAIOpenTelemetry(t *testing.T) {
 	}
 
 	t.Run("bedrock", func(t *testing.T) {
-		auditSpanOptional(t, "pydantic-ai", "opentelemetry-bedrock", BedrockProfile,
+		auditSpanOptionalWithMetrics(t, "pydantic-ai", "opentelemetry-bedrock", BedrockProfile,
 			`fetch spans, from: now()-10m
 | filter service.name == "pydantic-ai-music-agent"
 | filter gen_ai.provider.name == "AWS Bedrock" or gen_ai.system == "AWS Bedrock"
 | filter isNotNull(gen_ai.request.model)
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+			"pydantic-ai-music-agent", genAIClientMetrics)
 	})
 	t.Run("azure", func(t *testing.T) {
-		auditSpanOptional(t, "pydantic-ai", "opentelemetry-azure", AzureProfile,
+		auditSpanOptionalWithMetrics(t, "pydantic-ai", "opentelemetry-azure", AzureProfile,
 			`fetch spans, from: now()-10m
 | filter service.name == "pydantic-ai-music-agent"
 | filter gen_ai.provider.name == "Azure OpenAI" or gen_ai.system == "Azure OpenAI"
 | filter isNotNull(gen_ai.request.model)
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+			"pydantic-ai-music-agent", genAIClientMetrics)
 	})
 }


### PR DESCRIPTION
Adds  gen_ai.client.token.usage  and  gen_ai.client.operation.duration  to SDK integrations that emit spans but not the standard metrics.

Collector path ( spanmetrics  +  signal_to_metrics  connectors, Bindplane 1.105.0):

•  openai/openinference ,  aws-bedrock/openinference ,  aws-strands/opentelemetry 

OpenPipeline path ( samplingAwareHistogramMetric  +  samplingAwareValueMetric  extractors):

•  aws-strands/opentelemetry-openpipeline ,  pydantic-ai/opentelemetry 
