### PR TITLE
feat: add Cohere + Traceloop instrumentation example

### DIFF
--- a/.github/scripts/compute-e2e-matrix.sh
+++ b/.github/scripts/compute-e2e-matrix.sh
@@ -18,7 +18,8 @@ OA_ALL='[
   {"name":"haystack-oneagent","app_dir":"haystack/oneagent","test_file":"test/e2e/haystack_test.go","test_run":"TestHaystackOneAgent","otel_service_name":"haystack/oneagent"},
   {"name":"aws-bedrock-agents-oneagent","app_dir":"aws-bedrock-agents/oneagent","test_file":"test/e2e/aws_bedrock_agents_oneagent_test.go","test_run":"TestAWSBedrockAgentsOneAgent","otel_service_name":"aws-bedrock-agents/oneagent", "oneagent_warmup_seconds":"60"},
   {"name":"mistral-oneagent","app_dir":"mistral/oneagent","test_file":"test/e2e/mistral_test.go","test_run":"TestMistralOneAgent","otel_service_name":"mistral/oneagent","model":"mistral-small-latest"},
-  {"name":"langgraph-oneagent","app_dir":"langgraph/oneagent","test_file":"test/e2e/langgraph_oneagent_test.go","test_run":"TestLangGraphOneAgent","otel_service_name":"langgraph/oneagent"}
+  {"name":"langgraph-oneagent","app_dir":"langgraph/oneagent","test_file":"test/e2e/langgraph_oneagent_test.go","test_run":"TestLangGraphOneAgent","otel_service_name":"langgraph/oneagent"},
+  {"name":"cohere-traceloop","app_dir":"cohere/traceloop","test_file":"test/e2e/cohere_traceloop_test.go","test_run":"TestCohereTraceloop","otel_service_name":"cohere-traceloop"}
 ]'
 
 OC_ALL='[

--- a/cohere/traceloop/.env.sample
+++ b/cohere/traceloop/.env.sample
@@ -1,0 +1,2 @@
+COHERE_API_KEY=
+MODEL=command-r-08-2024

--- a/cohere/traceloop/Makefile
+++ b/cohere/traceloop/Makefile
@@ -1,0 +1,29 @@
+SHELL            := /bin/bash
+-include .env
+export
+
+APP_IMAGE        ?=
+BUILD_PLATFORM   ?= linux/amd64
+PORT             ?= 8000
+
+.PHONY: install run build push request help
+
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+install: ## Install Python dependencies
+	uv sync
+
+run: ## Run app locally on port $(PORT)
+	uv run python3 -m uvicorn app:app --host 0.0.0.0 --port $(PORT)
+
+build: ## Build container image  (APP_IMAGE, BUILD_PLATFORM)
+	docker buildx build --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) .
+
+push: ## Build and push container image to registry
+	docker buildx build --no-cache --platform $(BUILD_PLATFORM) -t $(APP_IMAGE) --push .
+
+request: ## POST /haiku to localhost:$(PORT)
+	curl -s -X POST http://localhost:$(PORT)/haiku \
+	  -H 'Content-Type: application/json' \
+	  -d '{"topic":"e2e test"}' | python3 -m json.tool

--- a/cohere/traceloop/app.py
+++ b/cohere/traceloop/app.py
@@ -1,0 +1,36 @@
+import asyncio
+import os
+import cohere
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+from traceloop.sdk import Traceloop
+
+Traceloop.init(app_name="cohere-traceloop")
+
+MODEL: str = os.environ.get("MODEL", "command-r-08-2024")
+
+app = FastAPI(title="cohere-traceloop")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+@app.post("/haiku", response_class=PlainTextResponse)
+async def haiku() -> str:
+    co = cohere.ClientV2(api_key=os.getenv("COHERE_API_KEY"))
+
+    def _call() -> str:
+        response = co.chat(
+            model=MODEL,
+            messages=[{"role": "user", "content": "Write a haiku."}],
+        )
+        return response.message.content[0].text
+
+    return await asyncio.to_thread(_call)
+
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/cohere/traceloop/pyproject.toml
+++ b/cohere/traceloop/pyproject.toml
@@ -1,0 +1,10 @@
+[project]
+name = "cohere-traceloop-demo"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = [
+    "cohere>=5.0.0",
+    "fastapi>=0.115.0",
+    "uvicorn>=0.30.0",
+    "traceloop-sdk>=0.33.0",
+]

--- a/test/e2e/cohere_traceloop_test.go
+++ b/test/e2e/cohere_traceloop_test.go
@@ -1,0 +1,27 @@
+package e2e
+
+import (
+	"testing"
+)
+
+func TestCohereTraceloop(t *testing.T) {
+	startCohereCompatibleMock(t)
+	startApp(t, "cohere/traceloop")
+	triggerHaiku(t, false)
+
+	// Traceloop instruments Cohere via the OpenLLMetry CohereInstrumentor.
+	// The OneAgent Python GenAI Cohere sensor must be DISABLED so that the
+	// suppression mechanism does not drop the Traceloop spans; OneAgent's OTel
+	// sensor then picks them up and nests them into the PurePath.
+	// Unlike the OneAgent-only path, Traceloop also captures gen_ai.input.messages
+	// and gen_ai.output.messages (prompt/response content).
+	auditSpan(t, "cohere", "traceloop", GenericProfile,
+		`fetch spans, from: now()-10m
+| filter service.name == "cohere-traceloop"
+| filter gen_ai.system == "Cohere"
+| filter isNotNull(gen_ai.request.model)
+| filter isNull(span.status_code) or span.status_code != "error"
+| sort timestamp desc
+| limit 1`,
+		"Backend mocked: in-process httptest stub intercepts Cohere SDK calls via CO_API_URL. Replace with a real COHERE_API_KEY secret for live validation. Requires the Python GenAI Cohere OneAgent feature flag to be DISABLED.")
+}


### PR DESCRIPTION
## What this adds

A new example under `cohere/traceloop/` that demonstrates using **Traceloop SDK** alongside OneAgent to get prompt/response capture for Cohere.

## Why

The OneAgent Cohere sensor (experimental) captures spans with model name, token counts and request attributes but **no prompt/response content**. 

OneAgent has a built-in suppression mechanism that drops OpenLLMetry/Traceloop spans when the matching OA sensor is active (to prevent duplicates). By **disabling the `Python GenAI Cohere` OA feature flag**, the suppression is lifted and Traceloop spans flow through OneAgent's OTel sensor, which nests them correctly into existing PurePaths.

## How it works
1. Disable the `Python GenAI Cohere` OneAgent feature flag
2. Keep the `Python OpenTelemetry` feature flag enabled
3. Run this example — Traceloop instruments Cohere, OneAgent's OTel sensor picks up the spans, full infra monitoring and other sensors remain untouched

> ⚠️ Note: `Traceloop.init()` instruments other providers too, but for anything where an OA sensor is still active, the suppression mechanism handles deduplication automatically.