### PR TITLE
chore: tune Renovate PR limits and disable lock file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -59,7 +59,33 @@
     },
     {
       "matchManagers": ["npm"],
-      "groupName": "npm dependencies"
+      "matchFileNames": ["langfuse/opentelemetry-node/**"],
+      "groupName": "npm dependencies (langfuse)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["rum/opentelemetry/nextjs-frontend/**"],
+      "groupName": "npm dependencies (rum)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["mcp/opentelemetry/mpc-server/**"],
+      "groupName": "npm dependencies (mcp)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["ai-coding-agents/openclaw-observability-plugin/otel-observability/**"],
+      "groupName": "npm dependencies (openclaw)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["ai-coding-agents/github-copilot-sdk/**"],
+      "groupName": "npm dependencies (github-copilot-sdk)"
+    },
+    {
+      "matchManagers": ["npm"],
+      "matchFileNames": ["openai-agents/opentelemetry/ui/**"],
+      "groupName": "npm dependencies (openai-agents)"
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,16 @@
       "datasourceTemplate": "docker"
     }
   ],
+  "prHourlyLimit": 20,
+  "lockFileMaintenance": {
+    "enabled": false
+  },
   "packageRules": [
+    {
+      "matchUpdateTypes": ["major"],
+      "prConcurrentLimit": 2,
+      "prPriority": -1
+    },
     {
       "matchManagers": ["pip_requirements", "pep621"],
       "groupName": "python dependencies"


### PR DESCRIPTION
- Disable lockFileMaintenance to fix deprecation warning about multiple npm lock files
- Raise prHourlyLimit to 20 to flush queued non-major updates
- Gate major updates to max 2 concurrent PRs with lower priority

workflow run here https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples/actions/runs/30611818466
