### PR TITLE
test: always create reports/ dir in TestMain

### DIFF
--- a/test/e2e/fixture_suite_test.go
+++ b/test/e2e/fixture_suite_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -41,6 +42,14 @@ func TestMain(m *testing.M) {
 	os.Setenv("OTEL_RESOURCE_ATTRIBUTES", runAttr)
 
 	dtClient = dynatrace.New(mustEnv("DT_APPS_ENDPOINT"), mustEnv("DT_API_TOKEN"))
+
+	// Pre-create the reports directory so the upload-artifact step always finds
+	// it, even when a test fails before auditSpan has a chance to write a report.
+	reportsDir := filepath.Join(repoRoot(), "test", "e2e", "reports")
+	if err := os.MkdirAll(reportsDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not create reports dir: %v\n", err)
+	}
+
 	os.Exit(m.Run())
 }
 


### PR DESCRIPTION
## Problem

The upload-artifact step in `e2e.yml` warns `No files were found with the provided path: test/e2e/reports/` when a test fails before `auditSpan` is reached (e.g. an `assertSpanExistsWithin` timeout). The `reports/` directory is only created lazily inside `writeReport`, so if the test exits early the directory never exists.

Observed in: `E2E / langgraph-oneagent`

## Fix

Pre-create `test/e2e/reports/` in `TestMain` so it always exists before any test runs, regardless of how far each test gets. `TestMain` runs once per `go test` invocation — before any `TestXxx` function — so this is the right place for package-level setup.