### PR TITLE
POC: aws-bedrock: custom evaluation as gen_ai.evaluation.result bizevent (stacked on #204)

### DIFF
--- a/aws-bedrock/opentelemetry/README.md
+++ b/aws-bedrock/opentelemetry/README.md
@@ -47,16 +47,17 @@ Set `BEDROCK_GUARDRAIL_ID` (and optionally `BEDROCK_GUARDRAIL_VERSION`, default 
 
 Agents that fan a single user turn out into several Bedrock calls (a router, one or more specialist agents, an LLM-as-judge) expose a correlation gap in the Prompts view. Traceloop stamps `gen_ai.*` on each **model-call** span, but not on the enclosing `@workflow` / `@agent` span. Because the Prompts view pairs input to output per `gen_ai` span, the intermediate calls produce half-rows (an input with no text output when the model returns a tool call, or an output with no user input when the input is a tool result), and no single span holds "user question to final answer".
 
-`run_multiagent_turn()` in `main.py` reproduces this and demonstrates the fix:
+`run_multiagent_turn()` in `main.py` reproduces this and demonstrates the fix plus an out-of-band evaluation:
 
 | Fix | Where | What it does |
 |---|---|---|
 | **Turn-level correlation** | `_stamp_turn_io()` | Records the whole turn on the **agent span** (`@agent`) so one clean `input -> output` record exists, using the message form (`gen_ai.input.messages` / `gen_ai.output.messages`) from the Dynatrace semantic dictionary. The span is typed as an agent (`gen_ai.operation.kind=agent`, `gen_ai.agent.name`) rather than a model call. Only the message form is set: the Prompts renderer appends both the flat form (`gen_ai.prompt.N` / `gen_ai.completion.0`) and the message form, so setting both would render the same turn twice. `gen_ai.provider.name=aws.bedrock` is set because the agent is Bedrock-backed; it is also what makes the app treat the span as a GenAI span (its filter is `isNotNull(gen_ai.system) or isNotNull(gen_ai.provider.name)`), so the turn shows in the Prompts view. |
+| **Evaluation as a separate signal (out-of-band)** | `evaluator.submit()` / `evaluator._run()` | Hands the turn to a background worker (`ThreadPoolExecutor`) so the evaluation runs off the request path, as a real deployment would. The worker ingests the verdict as a Dynatrace **Business Event** (`event.type = gen_ai.evaluation.result`) via `/api/v2/bizevents/ingest`, correlated to the turn by `trace_id` / `span_id`, so it lands on the Evaluations page instead of running as a `converse` call. It is also tagged with a `dt.eval.run_id` (`run-demo-standin-<timestamp>`); the Evaluations page is run-centric and keys its schema on that field, so a bizevent without one never appears there. The event also carries the turn's time range (`span.start_time` / `span.end_time`), which the app uses to locate the evaluated span, and a `timestamp` that the Evaluations page sorts by. Field names (`gen_ai.evaluation.score.value` / `.score.label`, `gen_ai.evaluation.input.question` / `.input.answer`) match what that page queries; static fields come from `evaluation_bizevent.json`. Falls back to an OTLP log when the bizevent env vars are not set, so local runs still work. |
 
 The router (`route_intent`) and specialist (`answer_agent`) calls still emit their own `gen_ai` model-call spans, so the Prompts view shows them as separate rows alongside the turn: the turn appears as an **Agent** row (it carries `gen_ai.agent.name`) and the internal steps as **LLM** rows. This is expected — the fix is that a correct turn-level `input -> output` record now exists, not that the steps disappear. If you want a conversation view with only turns, suppress the internal rows at the pipeline layer (for example an OpenPipeline DQL processor or OTel Collector `transform` that drops the internal spans, or removes their `gen_ai.*` attributes so they fall out of the app's GenAI filter, matched by `traceloop.entity.name` / `span.name`).
 
 > [!NOTE]
-> This is a demonstration, so the multi-agent turn is simplified from a real deployment: the fan-out is sequential rather than parallel with a synthesis step.
+> This is a demonstration, so a few things are simplified from a real deployment: the evaluator is a stand-in that always returns `pass` (a real one would call an actual judge or metric), the fan-out is sequential rather than parallel with a synthesis step, and the bizevent is sent per turn rather than batched.
 
 ## How to use
 
@@ -68,6 +69,7 @@ The router (`route_intent`) and specialist (`answer_agent`) calls still emit the
 - A running [OpenTelemetry Collector](#opentelemetry-collector) forwarding to Dynatrace
 - A Dynatrace environment with an API token that has the **`openTelemetryTrace.ingest`**, **`metrics.ingest`**, and **`logs.ingest`** scopes
 - Optional, for the guardrail story: set `BEDROCK_GUARDRAIL_ID` (and optionally `BEDROCK_GUARDRAIL_VERSION`, default `DRAFT`). When unset, the guardrail story is skipped
+- Optional, for the evaluation Business Event: set `DT_ENDPOINT` (for example `https://<env-id>.live.dynatrace.com`) and `DT_API_TOKEN` (token with the **`bizevents.ingest`** scope). When unset, `evaluator.submit()` falls back to an OTLP log
 
 ### Install dependencies
 
@@ -123,7 +125,7 @@ make run STORY=multiagent   # or a single story: converse | guardrails | invoke 
 
 The script runs continuously, replaying the selected story (or all four) every 5 seconds. Stop it with `Ctrl+C`.
 
-To confirm the turn-level correlation, open the Prompts view and filter to your service (`bedrock_example_app` by default, or your `OTEL_SERVICE_NAME` if you set one): the `multiagent_turn` agent span appears as one **Agent** row with the question as input and the answer as output, and the internal `route_intent` / `answer_agent` model calls appear as separate **LLM** rows (suppress these at the pipeline layer if you want a turns-only conversation view).
+To confirm the turn-level correlation, open the Prompts view and filter to your service (`bedrock_example_app` by default, or your `OTEL_SERVICE_NAME` if you set one): the `multiagent_turn` agent span appears as one **Agent** row with the question as input and the answer as output, and the internal `route_intent` / `answer_agent` model calls appear as separate **LLM** rows (suppress these at the pipeline layer if you want a turns-only conversation view). The evaluation stays out of the chat stream: it appears on the Evaluations page as a bizevent when `DT_ENDPOINT` / `DT_API_TOKEN` are set, otherwise as a `gen_ai.evaluation` OTLP log.
 
 ### Verify in Dynatrace
 
@@ -143,7 +145,7 @@ fetch spans, from:now()-1h
 | **1. Converse API** | `run_converse()` | One `gen_ai` span per Converse call: model ID, token usage, finish reason |
 | **2. Invoke API** | `run_invoke()` / `run_invoke_extra()` | Same signals via the alternate Bedrock Invoke API |
 | **3. Guardrails** | `run_converse_guardrail_trigger()` | A blocked request: `gen_ai.response.finish_reasons=["content_filter"]` plus `gen_ai.bedrock.guardrail.*` (see [Guardrails](#guardrails)) |
-| **4. Multi-agent turn** | `run_multiagent_turn()` | Turn-level input/output correlation on the agent span (see [Multi-agent turn](#multi-agent-turn-inputoutput-correlation-in-the-prompts-view)) |
+| **4. Multi-agent turn** | `run_multiagent_turn()` | Turn-level input/output correlation on the agent span, plus an evaluation Business Event (see [Multi-agent turn](#multi-agent-turn-inputoutput-correlation-in-the-prompts-view)) |
 
 By default all four run in one loop. To look at a single story with a focused trace, select it with the `STORY` variable (or a comma-separated list):
 
@@ -158,6 +160,8 @@ make run STORY=converse,invoke
 | File | Description |
 |---|---|
 | `main.py` | Fully instrumented entrypoint; auto-instruments Boto3, sets up Traceloop, and runs the four stories (converse, guardrails, invoke, multiagent) in a continuous loop, selectable via `STORY` |
+| `evaluator.py` | Out-of-band evaluator for the multi-agent turn; `submit()` queues the turn to a background worker and `_run()` ingests the verdict as a `gen_ai.evaluation.result` Business Event |
+| `evaluation_bizevent.json` | Static fields of the evaluation Business Event; `evaluator._run()` loads this and fills the per-run fields (score, verdict, question/answer, trace/span, run id, timestamps) |
 | `converse.py` | Minimal standalone example using the Converse API (no instrumentation) |
 | `invoke.py` | Minimal standalone example using the Invoke API (no instrumentation) |
 | `guard_rail_metrics.py` | Fetches Bedrock Guardrail metrics from CloudWatch (intervention count, latency, text units) |

--- a/aws-bedrock/opentelemetry/evaluation_bizevent.json
+++ b/aws-bedrock/opentelemetry/evaluation_bizevent.json
@@ -1,0 +1,11 @@
+{
+  "event.type": "gen_ai.evaluation.result",
+  "event.provider": "aws-bedrock-opentelemetry-example",
+  "gen_ai.evaluation.name": "non_empty_answer",
+  "gen_ai.evaluation.type": "heuristic",
+  "gen_ai.evaluation.version": "1",
+  "gen_ai.evaluation.spec_id": "non_empty_answer",
+  "gen_ai.evaluation.scoring_format": "score_0_to_1",
+  "gen_ai.evaluation.method": "heuristic",
+  "gen_ai.provider.name": "aws.bedrock"
+}

--- a/aws-bedrock/opentelemetry/evaluator.py
+++ b/aws-bedrock/opentelemetry/evaluator.py
@@ -1,0 +1,83 @@
+"""Out-of-band evaluation for the multi-agent turn.
+
+Runs off the request path in a background worker and emits a
+`gen_ai.evaluation.result` Business Event per turn, correlated to the turn by
+`trace_id` / `span_id`. The verdict is a stand-in that always passes; a real
+deployment would run an actual judge (LLM-as-judge or a metric). Static event
+fields live in `evaluation_bizevent.json`. See the README ("Multi-agent turn").
+"""
+import atexit
+import json
+import logging
+import os
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timezone
+
+import requests
+
+with open(os.path.join(os.path.dirname(__file__), "evaluation_bizevent.json")) as _f:
+    _FIELDS = json.load(_f)
+
+# The Evaluations page keys its schema on dt.eval.run_id; a bizevent without one never
+# appears there. Stamp one per process so this run's turns group together.
+_RUN_ID = "run-demo-standin-{ts}-{rand}".format(
+    ts=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H-%M-%S"),
+    rand=uuid.uuid4().hex[:8],
+)
+
+_POOL = ThreadPoolExecutor(max_workers=2)
+atexit.register(lambda: _POOL.shutdown(wait=True))
+
+
+def submit(span, question, answer, model, started, ended):
+    """Queue an evaluation for the turn and return immediately.
+
+    `started`/`ended` bound the turn span so the bizevent can carry its time range.
+    """
+    ctx = span.get_span_context()
+    fut = _POOL.submit(_run, question, answer, model,
+                       format(ctx.trace_id, "032x"), format(ctx.span_id, "016x"),
+                       started.isoformat(), ended.isoformat())
+    # Futures swallow worker exceptions; surface them so a failed eval is visible.
+    fut.add_done_callback(
+        lambda f: f.exception() and logging.error(f"evaluation worker failed: {f.exception()!r}"))
+
+
+def _run(question, answer, model, trace_id, span_id, span_start, span_end):
+    event = dict(_FIELDS)
+    event.update({
+        "trace_id": trace_id,
+        "span_id": span_id,
+        "dt.eval.run_id": _RUN_ID,
+        # Time range the app uses to locate the span; `timestamp` is the sort key.
+        "span.start_time": span_start,
+        "span.end_time": span_end,
+        "timestamp": span_end,
+        "gen_ai.evaluation.score.value": 1.0,
+        "gen_ai.evaluation.score.label": "pass",
+        "gen_ai.evaluation.explanation": "Stand-in evaluator: always passes.",
+        "gen_ai.evaluation.input.question": question,
+        "gen_ai.evaluation.input.answer": answer,
+        "gen_ai.request.model": model,
+    })
+    _ingest(event)
+
+
+def _ingest(event):
+    # POST to {DT_ENDPOINT}/api/v2/bizevents/ingest (token scope bizevents.ingest);
+    # fall back to an OTLP log when unset or on failure so local runs still work.
+    base = os.environ.get("DT_ENDPOINT", "").rstrip("/")
+    token = os.environ.get("DT_API_TOKEN", "")
+    if base and token:
+        try:
+            requests.post(f"{base}/api/v2/bizevents/ingest",
+                          headers={"Authorization": f"Api-Token {token}", "Content-Type": "application/json"},
+                          data=json.dumps(event), timeout=10).raise_for_status()
+            logging.info("eval bizevent ingested (span_id=%s)", event["span_id"])
+            return
+        except Exception as e:
+            logging.error(f"eval bizevent ingest failed: {e}")
+    else:
+        logging.warning("DT_ENDPOINT/DT_API_TOKEN not set; eval logged, not ingested as bizevent")
+    logging.info("gen_ai.evaluation", extra=event)

--- a/aws-bedrock/opentelemetry/main.py
+++ b/aws-bedrock/opentelemetry/main.py
@@ -10,6 +10,7 @@ from tenacity import sleep
 from traceloop.sdk import Traceloop
 import logging
 import json
+from datetime import datetime, timezone
 
 from opentelemetry.instrumentation.bedrock import BedrockInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
@@ -22,6 +23,8 @@ from opentelemetry._logs import set_logger_provider
 
 from traceloop.sdk.decorators import workflow, task, agent
 from opentelemetry import trace as _ot_trace
+
+import evaluator
 
 COLLECTOR_BASE_URL = "http://localhost:4318"
 MODEL_ID = "us.anthropic.claude-haiku-4-5-20251001-v1:0"
@@ -179,7 +182,7 @@ def run_invoke_extra(client_context):
 
 
 # Multi-agent turn: one user turn fans out into several Bedrock calls, recorded on the
-# agent span (see the README "Multi-agent turn" section).
+# agent span and evaluated out-of-band (see the README "Multi-agent turn" section).
 
 
 def _messages(role, text):
@@ -216,9 +219,13 @@ def answer_agent(client_context, question):
 @agent("multiagent_turn")
 def run_multiagent_turn(client_context, question):
     span = _ot_trace.get_current_span()
+    started = datetime.now(timezone.utc)
     route_intent(client_context, question)
     answer = answer_agent(client_context, question)
     _stamp_turn_io(span, question, answer)
+    # Pass the turn's wall-clock window so the eval bizevent can carry the span's time range.
+    ended = datetime.now(timezone.utc)
+    evaluator.submit(span, question, answer, MODEL_ID, started, ended)
     print(answer)
     return answer
 


### PR DESCRIPTION
## What

Stacked on #204 (multi-agent turn base). Adds an out-of-band **custom evaluation** to the `aws-bedrock/opentelemetry` multi-agent turn: after each turn, a stand-in judge emits a `gen_ai.evaluation.result` **Business Event** correlated to the turn span, so it lands on the Evaluations page instead of polluting the conversation stream.

> Draft: depends on #204. Review/merge #204 first; this branch targets `demo-turn-io-and-eval` and its diff is eval-only.

### Changes
- **`evaluator.py`** — `submit()` hands the turn to a `ThreadPoolExecutor` worker (off the request path); `_run()` builds the event and `_ingest()` POSTs to `{DT_ENDPOINT}/api/v2/bizevents/ingest` (scope `bizevents.ingest`), falling back to an OTLP log when env vars are unset.
- Event carries what the GenAI Observability app needs: `dt.eval.run_id` (run-centric Evaluations page keys on it), `span.start_time`/`span.end_time` (app locates the evaluated span by this range), `timestamp` (sort key), `gen_ai.evaluation.score.*`, and `gen_ai.evaluation.input.question`/`.answer`. Static fields live in `evaluation_bizevent.json`.
- **`main.py`** — wires `evaluator.submit(...)` into `run_multiagent_turn`, passing the turn's wall-clock window.
- README: evaluation-as-bizevent section + prerequisites.

## How to test
On top of #204's setup, set `DT_ENDPOINT` + `DT_API_TOKEN` (scope `bizevents.ingest`) and `make run STORY=multiagent`. The verdict appears on the Evaluations page grouped under one `run-demo-standin-…` run id; without the env vars it falls back to an OTLP log.

## Notes
- The judge is a stand-in that always passes — a real deployment would run an actual LLM-as-judge or metric.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
