### PR TITLE
Fix SDK delta: litellm (OpenTelemetry) 

### DIFF
--- a/litellm/opentelemetry/fastapi-instrumentation/main.py
+++ b/litellm/opentelemetry/fastapi-instrumentation/main.py
@@ -2,6 +2,7 @@ import litellm
 import logging
 import os
 import time
+import uuid
 from fastapi import FastAPI, HTTPException
 from litellm.integrations.opentelemetry import OpenTelemetry as LiteLLMOTel
 from opentelemetry import metrics
@@ -29,6 +30,9 @@ COLLECTOR_BASE_URL = os.environ["COLLECTOR_BASE_URL"]
 # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is rejected (HTTP 400).
 # Must be set before the OTLP metric exporter is constructed in Traceloop.init below.
 os.environ.setdefault("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", "delta")
+
+# Capture prompt/response content as span attributes (OFF by default in LiteLLM Otel v2, since it may contain sensitive data)
+os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "span_only")
 
 # Optional LLM provider keys — set in environment to enable each provider
 # Grok (xAI): use model prefix "xai/", e.g. "xai/grok-2-latest"
@@ -102,6 +106,7 @@ class ChatCompletionRequest(BaseModel):
     messages: list[ChatMessage]
     max_tokens: Optional[int] = None
     temperature: Optional[float] = None
+    conversation_id: Optional[str] = None
 
 
 @app.post("/chat/completions")
@@ -113,6 +118,10 @@ async def chat_completions(request: ChatCompletionRequest):
         kwargs["max_tokens"] = request.max_tokens
     if request.temperature is not None:
         kwargs["temperature"] = request.temperature
+    if request.conversation_id:
+        Traceloop.set_conversation_id(request.conversation_id)
+    else:
+        Traceloop.set_conversation_id(str(uuid.uuid4()))
 
     attrs = {"model": request.model}
     logger.info("chat request: model=%s", request.model)

--- a/litellm/opentelemetry/fastapi-instrumentation/main.py
+++ b/litellm/opentelemetry/fastapi-instrumentation/main.py
@@ -14,6 +14,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 from pydantic import BaseModel
 from typing import Optional
 from traceloop.sdk import Traceloop
+from traceloop.sdk.tracing.tracing import set_conversation_id
 
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
@@ -119,9 +120,9 @@ async def chat_completions(request: ChatCompletionRequest):
     if request.temperature is not None:
         kwargs["temperature"] = request.temperature
     if request.conversation_id:
-        Traceloop.set_conversation_id(request.conversation_id)
+        set_conversation_id(request.conversation_id)
     else:
-        Traceloop.set_conversation_id(str(uuid.uuid4()))
+        set_conversation_id(str(uuid.uuid4()))
 
     attrs = {"model": request.model}
     logger.info("chat request: model=%s", request.model)

--- a/litellm/opentelemetry/fastapi-instrumentation/main.py
+++ b/litellm/opentelemetry/fastapi-instrumentation/main.py
@@ -125,6 +125,7 @@ async def chat_completions(request: ChatCompletionRequest):
     system_message = next((m.content for m in request.messages if m.role == "system"), None)
     if system_message:
         kwargs["system_instructions"] = system_message
+        kwargs["additional_drop_params"] = ["system_instructions"]
 
     attrs = {"model": request.model}
     logger.info("chat request: model=%s", request.model)

--- a/litellm/opentelemetry/fastapi-instrumentation/main.py
+++ b/litellm/opentelemetry/fastapi-instrumentation/main.py
@@ -32,9 +32,6 @@ COLLECTOR_BASE_URL = os.environ["COLLECTOR_BASE_URL"]
 # Must be set before the OTLP metric exporter is constructed in Traceloop.init below.
 os.environ.setdefault("OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE", "delta")
 
-# Capture prompt/response content as span attributes (OFF by default in LiteLLM Otel v2, since it may contain sensitive data)
-os.environ.setdefault("OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT", "span_only")
-
 # Optional LLM provider keys — set in environment to enable each provider
 # Grok (xAI): use model prefix "xai/", e.g. "xai/grok-2-latest"
 # Groq:       use model prefix "groq/", e.g. "groq/llama-3.3-70b-versatile"
@@ -123,6 +120,11 @@ async def chat_completions(request: ChatCompletionRequest):
         set_conversation_id(request.conversation_id)
     else:
         set_conversation_id(str(uuid.uuid4()))
+
+    # Extract system message to populate gen_ai.system_instructions span attribute
+    system_message = next((m.content for m in request.messages if m.role == "system"), None)
+    if system_message:
+        kwargs["system_instructions"] = system_message
 
     attrs = {"model": request.model}
     logger.info("chat request: model=%s", request.model)

--- a/litellm/opentelemetry/fastapi-instrumentation/main.py
+++ b/litellm/opentelemetry/fastapi-instrumentation/main.py
@@ -121,11 +121,6 @@ async def chat_completions(request: ChatCompletionRequest):
     else:
         set_conversation_id(str(uuid.uuid4()))
 
-    # Extract system message to populate gen_ai.system_instructions span attribute
-    system_message = next((m.content for m in request.messages if m.role == "system"), None)
-    if system_message:
-        kwargs["system_instructions"] = system_message
-        kwargs["additional_drop_params"] = ["system_instructions"]
 
     attrs = {"model": request.model}
     logger.info("chat request: model=%s", request.model)

--- a/litellm/opentelemetry/otel-collector-config.yaml
+++ b/litellm/opentelemetry/otel-collector-config.yaml
@@ -11,6 +11,17 @@ processors:
     send_batch_size: 512
     timeout: 5s
 
+  transform/system_instructions:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["temp.input_messages"], ParseJSON(attributes["gen_ai.input.messages"])) where attributes["gen_ai.input.messages"] != nil
+          - set(attributes["gen_ai.system_instructions"], attributes["temp.input_messages"][0]["parts"][0]["content"]) where attributes["temp.input_messages"][0]["role"] == "system"
+          - delete_index(attributes["temp.input_messages"], 0) where attributes["temp.input_messages"][0]["role"] == "system"
+          - set(attributes["gen_ai.input.messages"], attributes["temp.input_messages"]) where attributes["temp.input_messages"] != nil
+          - delete_key(attributes, "temp.input_messages") where attributes["temp.input_messages"] != nil
+
 exporters:
   otlphttp/dynatrace:
     endpoint: "${env:DT_ENDPOINT}/api/v2/otlp"
@@ -21,7 +32,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [transform/system_instructions, batch]
       exporters: [otlphttp/dynatrace]
     metrics:
       receivers: [otlp]

--- a/litellm/opentelemetry/otel-collector-config.yaml
+++ b/litellm/opentelemetry/otel-collector-config.yaml
@@ -11,15 +11,6 @@ processors:
     send_batch_size: 512
     timeout: 5s
 
-  transform/system_instructions:
-    error_mode: ignore
-    trace_statements:
-      - context: span
-        statements:
-          - set(attributes["temp.input_messages"], ParseJSON(attributes["gen_ai.input.messages"])) where attributes["gen_ai.input.messages"] != nil
-          - set(attributes["gen_ai.system_instructions"], attributes["temp.input_messages"][0]["parts"][0]["content"]) where attributes["temp.input_messages"][0]["role"] == "system"
-          - delete_key(attributes, "temp.input_messages") where attributes["temp.input_messages"] != nil
-
 exporters:
   otlphttp/dynatrace:
     endpoint: "${env:DT_ENDPOINT}/api/v2/otlp"
@@ -30,7 +21,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [transform/system_instructions, batch]
+      processors: [batch]
       exporters: [otlphttp/dynatrace]
     metrics:
       receivers: [otlp]

--- a/litellm/opentelemetry/otel-collector-config.yaml
+++ b/litellm/opentelemetry/otel-collector-config.yaml
@@ -11,6 +11,15 @@ processors:
     send_batch_size: 512
     timeout: 5s
 
+  transform/system_instructions:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["temp.input_messages"], ParseJSON(attributes["gen_ai.input.messages"])) where attributes["gen_ai.input.messages"] != nil
+          - set(attributes["gen_ai.system_instructions"], attributes["temp.input_messages"][0]["parts"][0]["content"]) where attributes["temp.input_messages"][0]["role"] == "system"
+          - delete_key(attributes, "temp.input_messages") where attributes["temp.input_messages"] != nil
+
 exporters:
   otlphttp/dynatrace:
     endpoint: "${env:DT_ENDPOINT}/api/v2/otlp"
@@ -21,7 +30,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [transform/system_instructions, batch]
       exporters: [otlphttp/dynatrace]
     metrics:
       receivers: [otlp]

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -307,8 +307,10 @@ func triggerLiteLLMChat(t *testing.T) {
 	b, _ := json.Marshal(map[string]interface{}{
 		"model": model,
 		"messages": []map[string]string{
+			{"role": "system", "content": "You are an expert in observability and monitoring."},
 			{"role": "user", "content": "Write a haiku about observability"},
 		},
+		"temperature": 1.0,
 	})
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
 	if err != nil {


### PR DESCRIPTION
# Description

Adds optional span attributes to the `litellm/opentelemetry` [(AI-78)](https://dt-rnd.atlassian.net/browse/AI-78)

- **`gen_ai.conversation.id`** — generated per request in the app via `Traceloop.set_conversation_id(uuid.uuid4())` 
- **`gen_ai.request.temperature`** — passed through to `litellm.completion()` and captured automatically by LiteLLMOTel when set on the request; e2e trigger updated to send `temperature=1.0`
- **`gen_ai.system_instructions`** — added OTel Collector transform processor that extracts the system message from `gen_ai.input.messages` into a dedicated `gen_ai.system_instructions` span attribute, then uses `delete_index` on the parsed pcommon.Slice to remove it from the messages array (to avoid duplicated system prompts)

>**Note:** Ideally `conversation_id` would be generated by the caller (the e2e trigger) to better reflect real gateway usage. This is not done here because the e2e test module has no external Go dependencies and the standard library has no UUID generator. [](url)