### PR TITLE
bump openinference-instrumentation-bedrock to v0.1.44

### DIFF
--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -7,6 +7,28 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  # The boto3 converse API takes multi-part message content
+  # (messages[].content is a list of blocks), so the BedrockInstrumentor emits
+  # llm.input_messages.N.message.contents.J.message_content.text and leaves the
+  # flat llm.input_messages.N.message.content unset. gen_ai_normalizer's
+  # openinference source only reads the flat key, so gen_ai.input.messages /
+  # gen_ai.output.messages come out empty. Backfill the flat key from the first
+  # text part before normalization; the normalizer then builds the structured
+  # gen_ai.*.messages as usual. OTTL cannot iterate, so indices are enumerated —
+  # this demo sends one user message and gets one assistant message back, the
+  # extra indices only cover multi-turn variants.
+  transform/openinference_message_content:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(attributes["llm.input_messages.0.message.content"], attributes["llm.input_messages.0.message.contents.0.message_content.text"]) where attributes["llm.input_messages.0.message.content"] == nil and attributes["llm.input_messages.0.message.contents.0.message_content.text"] != nil
+          - set(attributes["llm.input_messages.1.message.content"], attributes["llm.input_messages.1.message.contents.0.message_content.text"]) where attributes["llm.input_messages.1.message.content"] == nil and attributes["llm.input_messages.1.message.contents.0.message_content.text"] != nil
+          - set(attributes["llm.input_messages.2.message.content"], attributes["llm.input_messages.2.message.contents.0.message_content.text"]) where attributes["llm.input_messages.2.message.content"] == nil and attributes["llm.input_messages.2.message.contents.0.message_content.text"] != nil
+          - set(attributes["llm.input_messages.3.message.content"], attributes["llm.input_messages.3.message.contents.0.message_content.text"]) where attributes["llm.input_messages.3.message.content"] == nil and attributes["llm.input_messages.3.message.contents.0.message_content.text"] != nil
+          - set(attributes["llm.output_messages.0.message.content"], attributes["llm.output_messages.0.message.contents.0.message_content.text"]) where attributes["llm.output_messages.0.message.content"] == nil and attributes["llm.output_messages.0.message.contents.0.message_content.text"] != nil
+          - set(attributes["llm.output_messages.1.message.content"], attributes["llm.output_messages.1.message.contents.0.message_content.text"]) where attributes["llm.output_messages.1.message.content"] == nil and attributes["llm.output_messages.1.message.contents.0.message_content.text"] != nil
+
   # Normalize OpenInference attributes to the OTel gen_ai.* semantic conventions.
   # The built-in "openinference" source maps model, provider, token usage, tool,
   # agent and session attributes, and reconstructs the flattened
@@ -112,14 +134,14 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [gen_ai_normalizer, transform/response_model, batch]
+      processors: [transform/openinference_message_content, gen_ai_normalizer, transform/response_model, batch]
       exporters: [otlp_http/dynatrace]
     # Second branch of the same spans: normalize, keep only LLM spans, and feed
     # the metric connectors. Kept separate from the export pipeline so the filter
     # here never drops spans from Distributed Tracing.
     traces/genai_metrics:
       receivers: [otlp]
-      processors: [gen_ai_normalizer, transform/response_model, filter/genai_only, batch]
+      processors: [transform/openinference_message_content, gen_ai_normalizer, transform/response_model, filter/genai_only, batch]
       exporters: [span_metrics, signal_to_metrics]
     metrics:
       receivers: [otlp, span_metrics, signal_to_metrics]

--- a/aws-bedrock/openinference/uv.lock
+++ b/aws-bedrock/openinference/uv.lock
@@ -280,7 +280,7 @@ wheels = [
 
 [[package]]
 name = "openinference-instrumentation-bedrock"
-version = "0.1.40"
+version = "0.1.44"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "dacite" },
@@ -292,9 +292,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/4b/2a31ddac9044beac5596f2fac923966794b134e59b48fc8871f4638b60fe/openinference_instrumentation_bedrock-0.1.40.tar.gz", hash = "sha256:cfec1e3f387cabb647d5f2ce7cda4919bf5a534d043391bddcd942a6f9d9b795", size = 227102, upload-time = "2026-05-22T21:10:43.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/0b/755f041e0e649ec1b35def0b4fa9455cb8f1e687d2ed20be2a986cadd982/openinference_instrumentation_bedrock-0.1.44.tar.gz", hash = "sha256:aca3d74944e02f2bbc5ce59f17dba6485e882e06f8e24ec590a7d85259648c69", size = 236046, upload-time = "2026-07-30T16:38:22.764Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/b3/4a23ddb98b5cff1da9a00b604df4978b8cf2bee54678c3803757f325f3c7/openinference_instrumentation_bedrock-0.1.40-py3-none-any.whl", hash = "sha256:822451f4f14a63347f77afc8dc1bb764c13682904757e8fa92ffcfb0395470d0", size = 66257, upload-time = "2026-05-22T21:10:42.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5b/f4cc97ee8360fc40d569f14bb8e4479d6c5381766dcb02cc11c918128978/openinference_instrumentation_bedrock-0.1.44-py3-none-any.whl", hash = "sha256:13c583f87589da3475864492a86ce84ba4b459b78031694d75ceca511002fbd6", size = 70094, upload-time = "2026-07-30T16:38:21.404Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes broken input/output message parts in converse spans emitted by the BedrockInstrumentor when using the boto3 converse API directly. v0.1.40 (previously pinned) did not correctly extract structured llm.input_messages / llm.output_messages attributes, causing empty gen_ai.input.messages / gen_ai.output.messages after normalization.

# Description

Please include a short summary of the changes and the related issue.

# Checklist

- [x] I've added/updated screenshots from the Dynatrace platform showing the changes.
- [x] I've added/updated the README with the changes.
