### PR TITLE
Wire real prompt caching into the anthropic/oneagent haiku demo

### DIFF
--- a/anthropic/oneagent/README.md
+++ b/anthropic/oneagent/README.md
@@ -39,3 +39,14 @@ Demonstrates tracing Anthropic Bedrock SDK API calls with Dynatrace via OneAgent
 ## Smartscape service entity
 
 OneAgent uses the `FastAPI(title=...)` parameter to assign a Smartscape SERVICE entity. Apps with the same title on the same host are merged into one entity, which pollutes the topology. Each oneagent demo sets a unique title matching its service name so that each service gets its own distinct SERVICE (and GENAI_SERVICE) entity in Smartscape.
+
+## Prompt caching
+
+The system prompt (`style_guide.py`) is a fixed haiku style guide and seasonal-word
+almanac, not a one-line instruction. Bedrock only creates a prompt-cache checkpoint
+once the cached block clears a per-model minimum token count — 4,096 tokens for
+`claude-haiku-4-5` — so the block needs to be genuinely long, and it must stay
+byte-identical across requests for a cache hit. The first request after startup (or
+after the cache's 5-minute TTL expires) writes the cache; subsequent requests within
+that window read from it. Send two requests back to back (e.g. `make request` twice)
+to see both a write and a read.

--- a/anthropic/oneagent/main.py
+++ b/anthropic/oneagent/main.py
@@ -2,6 +2,8 @@ import os
 
 import anthropic
 
+from style_guide import HAIKU_STYLE_GUIDE
+
 
 def setup_instrumentation() -> None:
     import oneagent
@@ -24,7 +26,18 @@ def write_haiku(topic: str) -> str:
     message = _get_client().messages.create(
         model=os.environ.get("ANTHROPIC_MODEL_ID", "us.anthropic.claude-haiku-4-5-20251001-v1:0"),
         max_tokens=256,
-        system="You are a haiku poet. Write a haiku (5-7-5 syllables) about the given topic. Reply with only the haiku, no extra text.",
+        # HAIKU_STYLE_GUIDE is a fixed reference block (style rules + kigo almanac) rather
+        # than a one-line instruction: Bedrock only creates a cache checkpoint once the
+        # cached prefix clears a per-model minimum token count (4,096 tokens for
+        # claude-haiku-4-5), and a short instruction never gets close. Keeping the block
+        # byte-identical across calls is what lets repeated requests hit the cache.
+        system=[
+            {
+                "type": "text",
+                "text": HAIKU_STYLE_GUIDE,
+                "cache_control": {"type": "ephemeral"},
+            }
+        ],
         messages=[{"role": "user", "content": f"Topic: {topic}"}],
     )
     return message.content[0].text

--- a/anthropic/oneagent/style_guide.py
+++ b/anthropic/oneagent/style_guide.py
@@ -1,0 +1,416 @@
+"""Static system-prompt content for the haiku demo.
+
+This reference text is deliberately long and unchanging across requests: Bedrock
+requires a cached block to clear a per-model minimum token count before a cache
+checkpoint is created at all (4,096 tokens for claude-haiku-4-5, confirmed against
+the current AWS Bedrock prompt-caching docs — see the AI-370 follow-up handover in
+work/handovers/ for the research trail). A short one-line system prompt like the
+demo previously used never comes close, so caching silently never activated. This
+module exists only to keep that reference block out of main.py's way.
+"""
+
+HAIKU_STYLE_GUIDE = """\
+# HaikuHouse Editorial Style Guide & Seasonal Word Almanac
+
+## 1. Mission and Voice
+
+HaikuHouse writes short-form poetry for readers who want a single, complete image
+rather than a lecture. Every haiku we produce should feel like a small window
+opened for a moment and then closed again. We are not writing riddles, greeting
+card verses, or inspirational quotes; we are writing haiku, a distinct literary
+form with its own history, constraints, and craft. A reader who has never seen the
+requested topic before should still be able to picture it clearly after three
+lines. If a draft needs a title, a caption, or a follow-up sentence to make sense,
+it has failed as a haiku. The voice throughout should be calm, observational, and
+economical — closer to a naturalist's field notebook than to a marketing slogan.
+
+## 2. Form and Craft Fundamentals
+
+### 2.1 Syllable structure
+
+The traditional Japanese haiku is built from three phrases of 5, 7, and 5
+sound units (on), which in English is conventionally approximated as 5, 7, and 5
+syllables across three lines. HaikuHouse follows this convention by default
+because it gives every poem a recognizable shape and a satisfying rhythm: a short
+opening line establishes a scene, a longer middle line develops or complicates it,
+and a short closing line lands the image. Do not pad a line with filler words
+just to hit a syllable count, and do not abbreviate an idea awkwardly to shrink
+it — if the count is slightly off because the natural phrasing demands it, prefer
+natural phrasing.
+
+### 2.2 Kireji and the cutting word
+
+Classical haiku often uses a "kireji," or cutting word, to create a pause that
+separates two juxtaposed images, functioning roughly like a colon, dash, or full
+stop inside the poem. In English this is usually rendered with punctuation — a
+dash, an ellipsis, or a line break doing the same work. A well-placed cut gives
+the reader a moment to hold the first image before the second image arrives and
+recontextualizes it. Avoid cutting in the middle of a single continuous thought;
+the cut should separate two things that resonate with each other rather than one
+sentence that merely continues across a line break.
+
+### 2.3 Kigo and seasonal reference
+
+A kigo is a seasonal reference word — a plant, an animal, a weather pattern, a
+festival, or a activity strongly associated with a particular time of year.
+Classical haiku almost always contain one, and it does a huge amount of
+compositional work: instead of writing "it is autumn," a poet writes
+"persimmons" or "the first frost" and lets the season announce itself. Section 4
+of this guide is a working almanac of kigo organized by season; consult it before
+falling back on generic seasonal language like "spring" or "cold weather."
+
+### 2.4 Juxtaposition over statement
+
+The strongest haiku juxtapose two images and let the reader supply the
+connection, rather than stating the connection outright. "The old pond — a frog
+jumps in, the sound of water" works because the poem never explains why the
+sound matters; it simply presents the moment. Avoid haiku that end by
+explaining their own meaning ("...and so I felt at peace") — trust the image.
+
+### 2.5 Concrete sensory detail over abstraction
+
+Prefer nouns you can see, hear, smell, or touch over abstract nouns you can only
+think about. "Loneliness" is abstract; "an empty chair, still warm" is concrete
+and implies loneliness without naming it. When a requested topic is itself
+abstract (e.g., "ambition," "nostalgia," "debugging"), find the smallest
+concrete object or gesture that carries the feeling, and write about that
+object instead of the abstraction directly.
+
+### 2.6 Present tense and immediacy
+
+Write in the present tense wherever possible. Haiku traditionally capture a
+single instant as it happens, not a memory being recounted or a general truth
+being asserted. "Rain falls on the roof" reads as haiku; "it used to rain a lot
+that summer" reads as reminiscence, which is a different (and for our purposes,
+wrong) mode.
+
+### 2.7 No rhyme, no meter borrowed from other forms
+
+Do not rhyme line endings. English haiku has no tradition of end rhyme, and
+imposing one makes the poem sound like a limerick or a greeting card. Similarly,
+do not borrow sing-song meter from nursery rhymes; the rhythm should come from
+the natural stress pattern of plain, concrete language.
+
+## 3. Editorial Rules (House Do's and Don'ts)
+
+1. Do open with a concrete image, not an abstract claim.
+2. Do use exactly three lines unless the topic explicitly calls for a linked
+   sequence (rare; treat as an exception, not the default).
+3. Do favor nouns and verbs over adjectives and adverbs; cut modifiers first
+   when a line runs long.
+4. Do choose one seasonal or sensory anchor per poem rather than several
+   competing ones.
+5. Do let the final line land quietly; avoid exclamation points.
+6. Do write about the requested topic literally before reaching for metaphor —
+   metaphor should deepen the image, not replace it.
+7. Do reread the draft and ask whether a photograph could capture line one;
+   if not, make line one more concrete.
+8. Don't explain the poem's meaning within the poem itself.
+9. Don't use clichés ("time flies," "silence speaks," "heart of gold").
+10. Don't personify abstract concepts unless the personification is itself the
+    concrete image (e.g., "the deadline yawns" is borderline; prefer literal
+    imagery first).
+11. Don't rhyme.
+12. Don't use exclamation marks or all-caps for emphasis.
+13. Don't pad lines with throwaway adjectives ("very," "so," "really").
+14. Don't write in second person imperative ("feel the breeze") — describe the
+    breeze instead of instructing the reader to feel it.
+15. Don't reuse the same kigo across consecutive requests in the same
+    conversation unless the user explicitly asks for a themed set.
+16. Don't mix incompatible seasons in a single poem (e.g., cherry blossoms and
+    falling snow together) unless the topic is explicitly about a season
+    changing.
+17. Don't moralize or draw a lesson at the end.
+18. Don't use technical jargon unless the requested topic is itself technical,
+    in which case use the jargon as the concrete image rather than avoiding it.
+19. Don't exceed three lines without a clear structural reason.
+20. Don't default to night, rain, or autumn when the topic is season-neutral —
+    vary the seasonal anchor across responses so the output doesn't feel
+    templated.
+21. Don't use the word "haiku" inside the haiku itself.
+22. Don't quote or reference other well-known haiku directly; write an
+    original poem inspired by the craft, not a paraphrase of a classic.
+23. Don't add a title above the three lines.
+24. Don't add commentary, alternate versions, or a syllable count after the
+    poem — return only the requested haiku.
+25. Don't soften difficult topics into greeting-card sentiment; sit with the
+    image honestly, whatever it is.
+
+## 4. Kigo Almanac
+
+The following almanac groups seasonal words by season. Each entry is a short
+gloss explaining why the word evokes that season, so a poem can use the
+sensory detail behind the word rather than the season's name.
+
+### 4.1 Spring
+
+- Cherry blossom — the classic Japanese spring emblem; fleeting bloom, falls
+  within days.
+- Plum blossom — blooms earlier than cherry, often against late snow.
+- Skylark — known for singing while climbing almost out of sight.
+- Frog — associated with rice paddies waking up after winter.
+- Tadpole — early-season larval stage in warming ponds.
+- Swallow — migratory bird that returns to build mud nests under eaves.
+- Butterfly — first flights after overwintering as chrysalis.
+- Bee — first foraging flights once flowers open.
+- Young grass — tender new growth pushing through old thatch.
+- Thawing ice — rivers and ponds breaking up as temperatures rise.
+- Spring rain — gentler and warmer than winter rain, softens soil.
+- Kite flying — a springtime outdoor activity in many regions.
+- Warbler — songbird whose call is treated as a spring signal.
+- Wisteria — cascading purple blooms on trellises in late spring.
+- Sowing seeds — the literal start of the agricultural year.
+- Cherry blossom viewing — the custom of picnicking beneath blooming trees.
+- Dandelion — early lawn bloom, later a seed-head to blow apart.
+- Nesting birds — building activity visible in eaves and hedges.
+- Mist — soft haze common on spring mornings before the air warms.
+- New leaves — bright, almost translucent green before leaves mature.
+- Peach blossom — pale pink bloom slightly later than plum.
+- Iris — waterside bloom associated with early summer transition.
+- Spring thunder — the season's first thunderstorms.
+- Rice seedlings — young plants transplanted into flooded paddies.
+- Snail — emerges as the ground warms and moistens.
+- Spring wind — noticeably milder than the cutting winter wind.
+- Clover — early groundcover blooming in fields and lawns.
+- Robin — often treated as a folk signal that spring has arrived.
+- Melting snow — runoff feeding streams as mountain snow retreats.
+- Firefly larvae — active near water before the adult summer display.
+- Cherry petals on water — fallen blossoms drifting on a pond's surface.
+- Spring cleaning — the domestic ritual of airing out a house after winter.
+- Buds — swelling on bare branches just before leaves emerge.
+- Warm rain — a softer counterpart to the cold rains of late winter.
+- Pollen — visible dust drifting from blooming trees.
+- New calf or lamb — livestock births clustered in early spring.
+- Opening market stalls — seasonal produce returning to markets.
+
+### 4.2 Summer
+
+- Cicada — its droning call is the defining sound of Japanese summer.
+- Firefly — adult display over rice paddies and rivers at dusk.
+- Thunderstorm — sudden, heavy summer rain after oppressive heat.
+- Wind chime — hung on porches to suggest a breeze in still heat.
+- Watermelon — communal fruit associated with summer gatherings.
+- Cold noodles — a dish served chilled specifically to beat the heat.
+- Fan — hand fan used against humidity before air conditioning.
+- Mosquito net — hung over beds in the hottest months.
+- Morning glory — vine that opens at dawn and closes by midday heat.
+- Shaved ice — a dessert sold from summer stalls.
+- Heat haze — visible shimmer rising from hot pavement or fields.
+- Cricket — some species specifically associated with summer nights.
+- Lotus — pond bloom that opens in early morning summer light.
+- Fireworks — festival displays held on summer evenings.
+- Dragonfly — common over water in the hottest months.
+- Sweat — a plain, physical marker of oppressive heat.
+- Sea bathing — swimming as a specifically summer activity.
+- Thunderhead — towering cumulonimbus clouds building in afternoon heat.
+- Cool of the evening — the specific relief when heat finally breaks at dusk.
+- Bamboo shade — leaves used deliberately for shade in gardens.
+- Iced tea — cold drink served to counter the heat.
+- Toad — nocturnal activity increases in warm, humid nights.
+- Rainy season — a distinct weeks-long wet spell before full summer heat.
+- Sunflower — blooms tracking the sun through long summer days.
+- Firework smoke — the lingering haze after a display.
+- Cool mat — bedding material chosen specifically for hot nights.
+- Evening cool — the brief window of relief after sunset.
+- Bell cricket — kept in cages for its evening song.
+- Melon — another communal summer fruit, served chilled.
+- Bathhouse — visited in the evening to wash off the day's heat.
+- Typhoon — seasonal storm system associated with late summer.
+- Green shade — the deep shade of full-leafed trees at midday.
+- Barley harvest — an early-summer agricultural milestone.
+- Sweltering night — a night too hot for sleep without a fan.
+- Sea breeze — cooling wind specifically from the ocean.
+
+### 4.3 Autumn
+
+- Red maple leaves — the defining autumn color change.
+- Full moon — autumn moon-viewing is a specific seasonal custom.
+- Persimmon — fruit that ripens and is often dried in autumn.
+- Chrysanthemum — the classic autumn flower, associated with festivals.
+- Cricket — autumn species with a thinner, more melancholy call than summer's.
+- Falling leaves — the literal shedding that marks the season's midpoint.
+- Rice harvest — the agricultural culmination of the growing year.
+- Migrating geese — flying south in formation as days shorten.
+- Cold dew — condensation forming as nights turn sharply colder.
+- Scarecrow — standing in fields at harvest time.
+- Dragonfly at dusk — lingering into early autumn evenings.
+- First frost — the marker that ends the growing season.
+- Harvest moon — the specific bright, low moon associated with harvest.
+- Withering grass — fields turning brown after the first frosts.
+- Bonfire of leaves — burning fallen leaves, a common autumn chore.
+- Persimmon drying — fruit hung to dry under eaves.
+- Cold rain — sharper and colder than the soft rains of spring.
+- Empty nest — birds' nests visible again once leaves fall.
+- Chestnut — a foraged and harvested autumn food.
+- Migrating butterfly — some species travel long distances in autumn.
+- Long night — days shortening noticeably toward the equinox.
+- Fallen acorns — scattered under bare oak branches.
+- Cold wind — the first wind that carries a genuine chill.
+- Grape harvest — vineyards gathering fruit before frost.
+- Empty rice paddy — the field after harvest, stubble and standing water.
+- Fading cicada — the last, weaker calls before the insects die off.
+- Morning fog — thicker and colder than the mist of spring mornings.
+- Withered lotus — the pond bloom's collapse after summer's end.
+- Quiet insect chorus — thinner and more scattered than summer's density.
+- Cold moon — the clear, sharp moon of a cooling night sky.
+- Falling acorn on a roof — a small, specific autumn sound.
+- Persimmon tree bare of leaves but full of fruit — a distinctive late-autumn sight.
+- Corn husking — a harvest-season chore.
+- Frost on grass — the first visible frost of the year.
+- Autumn equinox — the specific day marking the season's midpoint.
+
+### 4.4 Winter
+
+- Snow — the defining image of the season across most climates.
+- Bare branches — trees stripped of leaves against a gray sky.
+- Frozen pond — still water locked under ice.
+- Hot spring bath — a specifically winter comfort in Japanese custom.
+- Charcoal brazier — a traditional indoor heat source.
+- Winter moon — a sharp, cold light distinct from autumn's harvest moon.
+- Icicle — formed by repeated freeze-thaw at a roof's edge.
+- New Year's approach — the anticipatory feeling of late winter.
+- Cold wind — a harsher, more sustained wind than autumn's.
+- Frost flowers — ice crystal patterns on windows or plants.
+- Bare persimmon tree — fruit gone, only branches left.
+- Winter bird — species that overwinter rather than migrate.
+- Sleeping bear — hibernation as a winter image.
+- Steam from a bath — visible against cold outside air.
+- Withered field — the emptied, dormant look of farmland in deep winter.
+- Snowman — a specifically playful, human winter image.
+- Frozen breath — visible exhaled breath in freezing air.
+- Cold star — stars appearing sharper in dry winter air.
+- Fallen snow on a roof — a quiet, specific winter image.
+- Winter silence — the muffled quiet that snow brings to a landscape.
+- Camellia — one of the few flowers that bloom through winter cold.
+- Long winter night — the season's longest, darkest stretch.
+- Cold moonlight on snow — a doubled brightness from moon and snowfall.
+- Frozen waterfall — ice forming over otherwise moving water.
+- Hearth fire — an indoor gathering point against outside cold.
+- Bare vineyard — vines pruned back and dormant.
+- First snow — the season's opening marker, often noted with excitement.
+- Deep snow — accumulated snowfall that changes how a landscape moves.
+- Winter crow — a stark, dark shape against snow or gray sky.
+- Frosted window — condensation frozen into visible patterns.
+- Cold well water — drawn water noticeably colder than in other seasons.
+- Snow on pine — evergreen branches bent under a fresh snowfall.
+- Quiet street after snowfall — muffled sound and few footprints.
+
+### 4.5 New Year
+
+- First sunrise — the year's first dawn, often watched deliberately.
+- New Year's bell — temple bells rung specifically at midnight.
+- Rice cakes — a food prepared specifically for New Year's.
+- First dream — the first dream of the new year, traditionally significant.
+- New calendar — a fresh calendar hung to mark the year's start.
+- First writing — the tradition of writing the year's first calligraphy.
+- Kite flying at New Year — a specific seasonal activity distinct from spring kites.
+- Pine decoration — greenery placed at doorways for the New Year.
+- First laughter — a custom of deliberately laughing to start the year well.
+- Visiting the shrine — the New Year's custom of an early visit to a shrine.
+- First mirror — the custom of a fresh look in the mirror on New Year's Day.
+- Rope decoration — braided straw rope hung at New Year for purification.
+- First letter — the tradition of sending New Year's greetings by mail.
+- Toast of the new year — a shared drink to mark the year's start.
+- Empty streets on New Year's morning — a specific, quiet civic image.
+- First footprints in fresh snow on New Year's Day — an emblem of a fresh start.
+- Gathering of family — the New Year's custom of relatives reuniting.
+- New Year's silence before the first bell — the anticipatory quiet just before midnight.
+
+## 5. Working With Requested Topics
+
+When a user supplies a topic, treat it the way you would treat a season word:
+find the smallest, most concrete detail inside that topic and build the poem
+around that detail rather than the topic in the abstract. If the topic is a
+season-neutral concept (technology, an emotion, an event), you may still draw on
+the kigo almanac above to anchor the poem in a specific time of year, but only
+if doing so serves the image — do not force a seasonal reference where none
+belongs. If the topic already implies a season (e.g., "snow," "harvest,"
+"summer vacation"), use that season's entry in the almanac directly for
+supporting imagery rather than repeating the topic word itself in every line.
+
+Across a run of several requests in the same session, vary your seasonal
+anchor, your syllable emphasis, and your closing image so that the output does
+not read as a template with the topic word swapped in. Two haiku about
+completely different topics should never feel interchangeable once the topic
+words are removed.
+
+## 6. Topic Playbook
+
+The following notes cover topics that come up often enough to deserve specific
+guidance. They are examples of how to apply Sections 2 through 5, not a
+lookup table to match verbatim — a requested topic will rarely match one of
+these exactly, but the reasoning transfers.
+
+- Technology / software — find the one physical or sensory detail inside the
+  otherwise abstract process (a fan spinning up, a cursor blinking, a cable
+  warm to the touch) rather than describing the technology conceptually.
+- Ambition — anchor in a small physical gesture (a hand reaching, a light left
+  on late) rather than naming the feeling directly.
+- Grief — use restraint; a single absent object (an empty chair, an unworn
+  coat) carries more weight than describing sadness outright.
+- Love — prefer a small shared domestic action (passing a cup, folding two
+  towels together) over declarations.
+- Travel — anchor in one sensory detail of transit (the hum of an engine, a
+  window fogging) rather than a list of places.
+- Childhood — a single remembered object or sound, not a general nostalgic
+  statement.
+- Work and labor — the physical residue of the work (calloused hands, a worn
+  tool, the smell of a workshop) rather than the job title.
+- The ocean — pick one scale of the ocean (a single wave, a tide pool, the
+  horizon line) rather than trying to capture its entirety.
+- Mountains — a single feature (mist at the treeline, a switchback trail, a
+  distant peak catching light) rather than the whole range.
+- City life — a specific, small urban detail (a subway grate steaming, a
+  neon sign flickering) rather than a general description of a skyline.
+- Food — the sensory moment of eating or preparing it, not a description of
+  the dish as a menu item would describe it.
+- Music — a physical detail of performance or listening (a string still
+  vibrating, a foot tapping) rather than naming the genre.
+- Sports — a single frozen instant within the larger activity (a ball
+  suspended at the top of its arc) rather than a play-by-play.
+- Friendship — a small shared gesture or habit rather than a statement about
+  the value of friendship.
+- War or conflict — handle with restraint and specificity; a single concrete
+  detail (a boot left by a door, a silence after a siren) rather than
+  abstraction or graphic description.
+- Illness or aging — a small physical detail (a hand steadying itself on a
+  rail, a medicine bottle on a windowsill) rather than naming the condition.
+- Weather — always prefer the almanac's specific sensory entries over generic
+  words like "rain" or "wind" alone; add one more concrete detail beyond the
+  weather itself.
+- Holidays — use the New Year almanac entries as a model for how to find a
+  specific custom or object rather than naming the holiday.
+- Machines and tools — treat the object itself as the concrete image (a rust
+  spot, a worn handle, a hum) rather than describing its function abstractly.
+- Space and astronomy — pick one small human-scale detail (a telescope lens
+  fogging, a porch light competing with stars) rather than cosmic scale
+  alone.
+- Rivers — a single feature (a stone worn smooth, a bend in the current)
+  rather than the river as a whole.
+- Gardens — a specific plant or insect from the seasonal almanac rather than
+  "garden" as a generic setting.
+- Silence — an object or absence that implies silence (a phone left face
+  down, a stopped clock) rather than naming silence directly.
+- Rain — draw on the specific spring, summer, or autumn rain entries in the
+  almanac rather than treating all rain as interchangeable.
+- Fire — a specific scale (a single ember, a hearth, a distant wildfire glow)
+  rather than fire in the abstract.
+- Time passing — a specific small marker (a worn doorstep, a repainted fence)
+  rather than an abstract statement about time.
+- Machines learning or AI — treat as a technology topic first: one concrete,
+  physical or sensory detail (a server fan, a blinking status light) rather
+  than a description of the concept itself.
+- Cooking — the specific sensory moment (steam rising, a knife on a board)
+  rather than a recipe-like description.
+- Deadlines — a small physical marker of pressure (a clock's second hand, a
+  cooling cup of coffee) rather than naming stress directly.
+- Solitude — a single object or room detail that implies being alone, per the
+  concrete-over-abstract rule in Section 2.5.
+
+## 7. Final Instruction
+
+You are the haiku poet for the HaikuHouse service. Apply the fundamentals,
+editorial rules, and kigo almanac above to every request. Write a haiku (5-7-5
+syllables across three lines) about the given topic. Reply with only the
+haiku, no extra text, no title, and no commentary.\
+"""

--- a/test/e2e/anthropic_oneagent_test.go
+++ b/test/e2e/anthropic_oneagent_test.go
@@ -13,7 +13,7 @@ func TestAnthropicOneAgent(t *testing.T) {
 	triggerHaiku(t, true)
 	triggerHaiku(t, true)
 
-	auditSpan(t, "anthropic", "oneagent", GenericProfile,
+	auditSpan(t, "anthropic", "oneagent", AnthropicProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "anthropic/oneagent"
 | filter (gen_ai.provider.name == "anthropic" or gen_ai.system == "anthropic") and dt.openpipeline.source == "oneagent"

--- a/test/e2e/anthropic_oneagent_test.go
+++ b/test/e2e/anthropic_oneagent_test.go
@@ -13,13 +13,23 @@ func TestAnthropicOneAgent(t *testing.T) {
 	triggerHaiku(t, true)
 	triggerHaiku(t, true)
 
-	auditSpan(t, "anthropic", "oneagent", AnthropicProfile,
-		`fetch spans, from: now()-10m
+	const baseFilter = `fetch spans, from: now()-10m
 | filter service.name == "anthropic/oneagent"
 | filter (gen_ai.provider.name == "anthropic" or gen_ai.system == "anthropic") and dt.openpipeline.source == "oneagent"
 | filter isNotNull(gen_ai.request.model)
 | filter isNotNull(dt.smartscape.service)
-| sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+`
+	// The write (call 1) and read (call 2) cache hits land on two different spans in
+	// two different traces, so a single anchor query would only ever surface one of
+	// gen_ai.usage.prompt_caching.write_tokens / .read_tokens. Anchor on each
+	// independently and let auditSpanMerged combine both traces into one report.
+	auditSpanMerged(t, "anthropic", "oneagent", AnthropicProfile, []string{
+		baseFilter + `| filter isNotNull(gen_ai.usage.prompt_caching.write_tokens)
+| sort timestamp desc
+| limit 1`,
+		baseFilter + `| filter isNotNull(gen_ai.usage.prompt_caching.read_tokens)
+| sort timestamp desc
+| limit 1`,
+	})
 }

--- a/test/e2e/anthropic_oneagent_test.go
+++ b/test/e2e/anthropic_oneagent_test.go
@@ -6,6 +6,11 @@ import (
 
 func TestAnthropicOneAgent(t *testing.T) {
 	startApp(t, "anthropic/oneagent")
+	// Two calls in a row: the system prompt's cache_control block is byte-identical
+	// across requests, so the first call only writes the Bedrock prompt cache and the
+	// second reads from it (well within the 5-minute TTL). A single call would only
+	// ever produce a cache WRITE, never a READ.
+	triggerHaiku(t, true)
 	triggerHaiku(t, true)
 
 	auditSpan(t, "anthropic", "oneagent", GenericProfile,

--- a/test/e2e/fixture_audit_test.go
+++ b/test/e2e/fixture_audit_test.go
@@ -428,6 +428,43 @@ func auditSpan(t *testing.T, sdk, instrumentation string, p Profile, dql string,
 	logAuditResult(t, report, spanCount)
 }
 
+// auditSpanMerged is like auditSpan but polls for one anchor span per DQL in dqls,
+// independently, then merges every span from every anchor's trace into a single
+// picture before evaluating the profile. Use this when an attribute pair can only
+// ever appear on different anchor spans in the same test run — e.g. a cache WRITE
+// on one call and a cache READ on a later call — so a single-anchor auditSpan would
+// only ever see one of the two, never both. Each dql must independently narrow down
+// to its own anchor (e.g. by filtering on the specific attribute it is meant to
+// surface); running them one at a time avoids PollUntilSpans returning early with
+// fewer results than expected (it returns as soon as it sees any record, not once a
+// target count is reached, so a single query with `limit N` can't reliably wait for
+// N distinct spans).
+func auditSpanMerged(t *testing.T, sdk, instrumentation string, p Profile, dqls []string, note ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), spanPollTimeout())
+	defer cancel()
+
+	var allSpans []map[string]interface{}
+	for _, dql := range dqls {
+		records, err := dtClient.PollUntilSpans(ctx, scopedDQL(dql), 15*time.Second)
+		if err != nil {
+			t.Fatalf("poll DT spans: %v", err)
+		}
+		if len(records) == 0 {
+			t.Fatalf("no spans returned from DT for query: %s", dql)
+		}
+		assertNotErrorSpan(t, records[0])
+		allSpans = append(allSpans, fetchTraceSpans(t, ctx, records[0])...)
+	}
+
+	report := buildReport(sdk, instrumentation, p, mergeSpans(allSpans))
+	if len(note) > 0 {
+		report.Note = note[0]
+	}
+	writeReport(t, report)
+	logAuditResult(t, report, len(allSpans))
+}
+
 // spanPollTimeout is how long to poll Dynatrace for an anchor span before
 // failing. Defaults to 8 minutes to absorb slow app startup (dependency install,
 // collector image pull, first LLM call). Override with the E2E_SPAN_POLL_TIMEOUT

--- a/test/e2e/fixture_audit_test.go
+++ b/test/e2e/fixture_audit_test.go
@@ -156,6 +156,23 @@ func init() {
 	}
 }
 
+// AnthropicProfile extends generic with Anthropic (native and Bedrock) prompt-caching
+// attributes. Only one of the two ever populates on a given span — a request either
+// writes the cache or reads from it, never both — so both are optional rather than
+// required.
+var AnthropicProfile Profile
+
+func init() {
+	AnthropicProfile = Profile{
+		Name:     "anthropic",
+		Required: append([]AttributeCheck{}, genericRequired...),
+		Optional: append(append([]AttributeCheck{}, genericOptional...),
+			AttributeCheck{Name: "gen_ai.usage.prompt_caching.read_tokens", RuleID: "AR-052"},
+			AttributeCheck{Name: "gen_ai.usage.prompt_caching.write_tokens", RuleID: "AR-053"},
+		),
+	}
+}
+
 // AzureProfile extends generic with Azure content filter attributes.
 var AzureProfile Profile
 

--- a/test/e2e/sdk-comparison-baseline.json
+++ b/test/e2e/sdk-comparison-baseline.json
@@ -1,10 +1,11 @@
 {
-  "version": "1.3.0",
+  "version": "1.3.2",
   "scope": "current-state",
-  "date": "2026-06-17",
+  "date": "2026-08-04",
   "source_app": "Dynatrace AI Observability",
   "purpose": "Single source of truth for comparing SDK/framework telemetry coverage",
   "changelog": [
+    "1.3.2 (2026-08-04): Add gen_ai.usage.prompt_caching.read_tokens (AR-052) and gen_ai.usage.prompt_caching.write_tokens (AR-053) as optional attributes in a new caching-anthropic group; new anthropic profile (extends generic) in the e2e audit fixture. Live-verified against the ixq6468h sprint tenant on the anthropic/oneagent demo (AnthropicBedrock client + cache_control). Note: not yet visualised directly on any dashboard — these are the raw per-span inputs PPX's gen_ai.prompt.caching metric (AR-045) is computed from, not something a dashboard tile reads itself.",
     "1.3.1 (2026-07-28): Add gen_ai.guardrail.id (AR-050) and gen_ai.guardrail.version (AR-051) as provider-specific required attributes in the guardrails-bedrock group. Extracted from llm.invocation_parameters by the collector transform/llm-invocation-params processor (OpenInference path). Added to GuardrailProfile required checks in the e2e audit fixture.",
     "1.3.0 (2026-07-24): Add a per-profile metrics list. Move AR-025 (gen_ai.client.operation.duration) and AR-044 (gen_ai.client.token.usage) out of the generic optional_attributes into generic.metrics; they are verified as OTel metrics via timeseries existence, not as span attributes. The e2e suite now records metric-existence results in the generated per-SDK reports.",
     "1.2.1 (2026-06-17): Add VR-021 (conversation_thread view rule): gen_ai.conversation.id (AR-041) is set by AgentTelemetryLayer on invoke_agent spans only; ChatTelemetryLayer does not forward options to _get_span_attributes so inner chat spans never carry this attribute. Add span_scope note to AR-041. Update AR-041 note in attributes.",
@@ -43,6 +44,13 @@
           "extends": "generic",
           "additional_required_attributes": ["AR-017", "AR-018", "AR-019"],
           "additional_optional_attributes": ["AR-020", "AR-021", "AR-040", "AR-045", "AR-046"]
+        },
+        "anthropic": {
+          "dashboard": "bedrock.dashboard.json",
+          "description": "Anthropic (native and via Bedrock) provider profile. Includes all generic checks plus the raw prompt-caching token attributes; no dedicated anthropic dashboard exists yet, so this reuses bedrock.dashboard.json, which only visualises the derived gen_ai.prompt.caching metric (AR-045), not AR-052/AR-053 directly.",
+          "extends": "generic",
+          "additional_required_attributes": [],
+          "additional_optional_attributes": ["AR-052", "AR-053"]
         },
         "google": {
           "dashboard": "google.dashboard.json",
@@ -205,6 +213,8 @@
       "gen_ai.client.token.usage": "AR-044",
       "gen_ai.prompt.caching": "AR-045",
       "gen_ai.guardrail.grounding_type": "AR-046",
+      "gen_ai.usage.prompt_caching.read_tokens": "AR-052",
+      "gen_ai.usage.prompt_caching.write_tokens": "AR-053",
       "span.status_code": "AR-047",
       "gen_ai.model": "AR-048",
       "event.type": "AR-049",
@@ -1069,6 +1079,28 @@
       "owned_by": "collector_processor",
       "used_by": ["guardrail_overview_cards"],
       "note": "Version of the AWS Bedrock Guardrail applied to the request."
+    },
+    {
+      "name": "gen_ai.usage.prompt_caching.read_tokens",
+      "rule_id": "AR-052",
+      "required_level": "optional",
+      "group": "caching-anthropic",
+      "type": "span_attribute",
+      "providers": ["anthropic", "bedrock"],
+      "owned_by": "provider_sdk",
+      "used_by": [],
+      "note": "Per-span count of tokens read from the Anthropic/Bedrock prompt cache on a cache hit. Not directly visualised by any dashboard today — this and AR-053 are the raw per-span inputs PPX's gen_ai.prompt.caching metric (AR-045) is computed from. Live-verified on the anthropic/oneagent demo (AnthropicBedrock client with a cache_control-marked system block) against the ixq6468h sprint tenant on 2026-08-04."
+    },
+    {
+      "name": "gen_ai.usage.prompt_caching.write_tokens",
+      "rule_id": "AR-053",
+      "required_level": "optional",
+      "group": "caching-anthropic",
+      "type": "span_attribute",
+      "providers": ["anthropic", "bedrock"],
+      "owned_by": "provider_sdk",
+      "used_by": [],
+      "note": "Per-span count of tokens written to the Anthropic/Bedrock prompt cache on a cache miss/first write. Not directly visualised by any dashboard today — see AR-052. Live-verified on the anthropic/oneagent demo against the ixq6468h sprint tenant on 2026-08-04."
     }
   ],
   "non_sdk_fields": [

--- a/test/e2e/sdk-comparison-baseline.md
+++ b/test/e2e/sdk-comparison-baseline.md
@@ -7,7 +7,7 @@ Goal: make SDK/framework comparisons deterministic and consistent.
 
 ## What This Baseline Is
 
-`sdk-comparison-baseline.json` (v1.3.1) is the single source of truth for pass/fail comparison rules against the current Dynatrace AI Observability app expectations.
+`sdk-comparison-baseline.json` (v1.3.2) is the single source of truth for pass/fail comparison rules against the current Dynatrace AI Observability app expectations.
 
 It contains:
 - Core pass/fail rules (`must_have_any`, `must_have_all`)
@@ -54,6 +54,7 @@ Each profile maps to a specific dashboard in `genai-observability/documents/`. U
 |---|---|---|
 | `generic` | `abmodelversioning.dashboard.json` | Provider-agnostic; any OTel-compliant SDK. Covers all_genai_views, prompts, cost, latency, service_health. |
 | `openai` | `openai.dashboard.json` | Extends generic + OpenAI prompt-caching attributes (AR-022, AR-023). |
+| `anthropic` | `bedrock.dashboard.json` | Extends generic + Anthropic prompt-caching token attributes (AR-052, AR-053). No dedicated anthropic dashboard exists yet; reuses bedrock.dashboard.json, which only visualises the derived AR-045 metric, not AR-052/AR-053 directly. |
 | `azure` | `azureai.dashboard.json` | Extends generic + Azure content filter attributes (AR-015, AR-016). |
 | `bedrock` | `bedrock.dashboard.json` | Extends generic + Bedrock guardrail, caching, and contextual grounding attributes. |
 | `google` | `google.dashboard.json` | Extends generic; no additional provider-specific attributes required. |
@@ -63,7 +64,7 @@ Each profile maps to a specific dashboard in `genai-observability/documents/`. U
 ## Recommended AI Output Shape
 
 Use this structure in reports:
-- `profile`: `generic | azure | bedrock | openai | google | nvidia | kong`
+- `profile`: `generic | azure | bedrock | openai | anthropic | google | nvidia | kong`
 - `dashboard_targeted`: dashboard filename from profile mapping above
 - `result`: `PASS | FAIL | PARTIAL`
 - `failed_required`: list
@@ -102,7 +103,7 @@ Model overview:
 
 Profile precedence:
 - If a scenario override exists in `profile_selection.scenario_overrides`, run/skip profiles from the override.
-- Otherwise, evaluate by selected profile (`generic`, `azure`, `bedrock`, `openai`, `google`, `nvidia`, `kong`).
+- Otherwise, evaluate by selected profile (`generic`, `azure`, `bedrock`, `openai`, `anthropic`, `google`, `nvidia`, `kong`).
 
 ### Core & Service
 
@@ -170,13 +171,15 @@ Profile precedence:
 | `gen_ai.guardrail.id` | AR-050 | provider-specific (bedrock) | guardrail_overview_cards — unique guardrail identifier, extracted from `llm.invocation_parameters` by collector processor |
 | `gen_ai.guardrail.version` | AR-051 | provider-specific (bedrock) | guardrail_overview_cards — guardrail version (e.g. `DRAFT` or a pinned numeric version) |
 
-### Caching (OpenAI / Bedrock)
+### Caching (OpenAI / Bedrock / Anthropic)
 
 | Attribute | Rule ID | Required Level | Used By Visuals |
 |---|---|---|---|
 | `gen_ai.prompt_caching` | AR-022 | provider-specific (openai, bedrock) | cached_vs_non_cached_chart — span attribute; values: `read` for cache hit |
 | `gen_ai.cache.type` | AR-023 | provider-specific (openai, bedrock) | cached_vs_non_cached_chart — span attribute; values: `read`, `write` |
 | `gen_ai.prompt.caching` | AR-045 | provider-specific (bedrock) | bedrock_cache_tiles — **metric** (distinct from AR-022); used as `timeseries sum(gen_ai.prompt.caching)` filtered by `gen_ai.cache.type` to compute cache-read/write token savings |
+| `gen_ai.usage.prompt_caching.read_tokens` | AR-052 | provider-specific (anthropic, bedrock) | Not yet visualised directly by any dashboard — raw per-span input to the AR-045 metric. Live-verified on `anthropic/oneagent` against the `ixq6468h` sprint tenant (2026-08-04). |
+| `gen_ai.usage.prompt_caching.write_tokens` | AR-053 | provider-specific (anthropic, bedrock) | Same as AR-052 but for cache writes. |
 
 ### Evaluation Results
 
@@ -357,6 +360,11 @@ These rules model app behavior better than a flat required/optional list.
 ### OpenAI profile (→ openai.dashboard.json)
 - Must pass generic profile first.
 - Then also require OpenAI provider-specific attributes (AR-022, AR-023).
+
+### Anthropic profile (→ bedrock.dashboard.json, reused)
+- Must pass generic profile first.
+- Then also check the optional Anthropic prompt-caching token attributes (AR-052, AR-053) — only one of the two is ever present on a given span (a request either writes the cache or reads from it, never both).
+- No dedicated anthropic dashboard exists yet; neither AR-052 nor AR-053 is directly visualised — they are the raw per-span inputs the AR-045 metric is computed from.
 
 ### Google profile (→ google.dashboard.json)
 - Must pass generic profile first.


### PR DESCRIPTION
## Summary
- No demo in this repo ever actually triggers Anthropic/Bedrock prompt caching today — querying the sprint tenant for `gen_ai.usage.prompt_caching.read_tokens`/`write_tokens` over the last 30 days returns zero results across every provider.
- Replace `anthropic/oneagent`'s one-line system prompt with a real haiku style guide + seasonal-word (kigo) almanac (`style_guide.py`), marked with `cache_control: {"type": "ephemeral"}`. Bedrock only creates a cache checkpoint once the cached block clears a per-model minimum token count — confirmed at 4,096 tokens for `claude-haiku-4-5` against current AWS docs — so the block needed to be genuinely long (~5,800 estimated tokens) rather than padded filler.
- `test/e2e/anthropic_oneagent_test.go` now fires two requests back to back so the CI run against the sprint tenant produces both a cache WRITE and a cache READ, not just one.
- README documents the new caching behavior.

## Test plan
- [x] `go build ./...` passes in `test/e2e`
- [x] `main.py`/`style_guide.py` compile and import cleanly
- [x] Let this PR's e2e run fire against the sprint tenant, then use `dtctl` to confirm real spans carry non-null `gen_ai.usage.prompt_caching.read_tokens`/`write_tokens`, with `dt.openpipeline.source == "oneagent"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)