### PR TITLE
Stitch multi-turn conversation spans/traces in openai-cs-agents

### DIFF
--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -268,9 +268,12 @@ async def chat_endpoint(req: ChatRequest):
     # Resolve the conversation identity BEFORE opening the span. Each turn is its
     # own trace, so stitching a multi-turn conversation together needs both a stable
     # conversation_id (reused across turns) and a span link back to the prior turn.
-    existing_state = conversation_store.get(req.conversation_id) if req.conversation_id else None
+    # Honor a caller-supplied conversation_id so a client can keep one stable id
+    # across turns; mint one only when the caller doesn't provide it. (Previously an
+    # unknown caller id was discarded and replaced per turn, so turns never stitched.)
+    conversation_id: str = req.conversation_id or uuid4().hex
+    existing_state = conversation_store.get(conversation_id)
     is_new = existing_state is None
-    conversation_id: str = uuid4().hex if is_new else req.conversation_id  # type: ignore
 
     # Link this turn's trace back to the previous turn's root span, when known.
     turn_links: List[trace.Link] = []

--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -55,6 +55,40 @@ _logging.getLogger().addHandler(_otel_log_handler)
 from opentelemetry import trace
 tracer = trace.get_tracer("openai-agents")
 
+# =========================
+# Conversation-id propagation
+# =========================
+# Each chat turn arrives as its own request and therefore its own trace. To stitch
+# a whole conversation back together we (1) set a stable gen_ai.conversation.id on
+# the turn's root span, (2) publish it to OTel baggage in /chat so the agent/model/
+# tool child spans created by the Agents SDK + Traceloop inherit it (via the span
+# processor below), and (3) link each turn's trace to the previous turn's.
+from opentelemetry import baggage, context as otel_context
+from opentelemetry.sdk.trace import SpanProcessor as _SpanProcessor
+
+GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id"
+
+
+class _ConversationIdSpanProcessor(_SpanProcessor):
+    """Stamp gen_ai.conversation.id from baggage onto every span at start."""
+
+    def on_start(self, span, parent_context=None):
+        conv_id = baggage.get_baggage(GEN_AI_CONVERSATION_ID, parent_context)
+        if conv_id:
+            span.set_attribute(GEN_AI_CONVERSATION_ID, conv_id)
+
+    def on_end(self, span):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000):
+        return True
+
+
+trace.get_tracer_provider().add_span_processor(_ConversationIdSpanProcessor())
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -227,15 +261,34 @@ def health():
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(req: ChatRequest):
-    with tracer.start_as_current_span(name="/chat", kind=trace.SpanKind.SERVER) as span:
-        """
-        Main chat endpoint for agent orchestration.
-        Handles conversation state, agent routing, and guardrail checks.
-        """
+    """
+    Main chat endpoint for agent orchestration.
+    Handles conversation state, agent routing, and guardrail checks.
+    """
+    # Resolve the conversation identity BEFORE opening the span. Each turn is its
+    # own trace, so stitching a multi-turn conversation together needs both a stable
+    # conversation_id (reused across turns) and a span link back to the prior turn.
+    existing_state = conversation_store.get(req.conversation_id) if req.conversation_id else None
+    is_new = existing_state is None
+    conversation_id: str = uuid4().hex if is_new else req.conversation_id  # type: ignore
+
+    # Link this turn's trace back to the previous turn's root span, when known.
+    turn_links: List[trace.Link] = []
+    if existing_state is not None:
+        prev_ctx = existing_state.get("last_span_context")
+        if prev_ctx is not None:
+            turn_links.append(
+                trace.Link(prev_ctx, attributes={"gen_ai.conversation.link": "previous_turn"})
+            )
+
+    with tracer.start_as_current_span(
+        name="/chat", kind=trace.SpanKind.SERVER, links=turn_links
+    ) as span:
+        # gen_ai.conversation.id ties every turn of this chat together.
+        span.set_attribute(GEN_AI_CONVERSATION_ID, conversation_id)
+
         # Initialize or retrieve conversation state
-        is_new = not req.conversation_id or conversation_store.get(req.conversation_id) is None
         if is_new:
-            conversation_id: str = uuid4().hex
             ctx = create_initial_context()
             current_agent_name = triage_agent.name
             state: Dict[str, Any] = {
@@ -249,6 +302,7 @@ async def chat_endpoint(req: ChatRequest):
                 ctx.account_number,
             )
             if req.message.strip() == "":
+                state["last_span_context"] = span.get_span_context()
                 conversation_store.save(conversation_id, state)
                 return ChatResponse(
                     conversation_id=conversation_id,
@@ -260,8 +314,7 @@ async def chat_endpoint(req: ChatRequest):
                     guardrails=[],
                 )
         else:
-            conversation_id = req.conversation_id  # type: ignore
-            state = conversation_store.get(conversation_id)
+            state = existing_state
 
         current_agent = _get_agent_by_name(state["current_agent"])
         logger.info(
@@ -274,6 +327,11 @@ async def chat_endpoint(req: ChatRequest):
         old_context = state["context"].model_dump().copy()
         guardrail_checks: List[GuardrailCheck] = []
 
+        # Publish the conversation id to baggage so every child span created during
+        # the agent run (model calls, tool calls, guardrails) inherits it.
+        _conv_token = otel_context.attach(
+            baggage.set_baggage(GEN_AI_CONVERSATION_ID, conversation_id)
+        )
         try:
             result = await Runner.run(current_agent, state["input_items"], context=state["context"])
         except InputGuardrailTripwireTriggered as e:
@@ -308,6 +366,8 @@ async def chat_endpoint(req: ChatRequest):
                 agents=_build_agents_list(),
                 guardrails=guardrail_checks,
             )
+        finally:
+            otel_context.detach(_conv_token)
 
         messages: List[MessageResponse] = []
         events: List[AgentEvent] = []
@@ -421,6 +481,8 @@ async def chat_endpoint(req: ChatRequest):
 
         state["input_items"] = result.to_input_list()
         state["current_agent"] = current_agent.name
+        # Record this turn's root span so the next turn can link back to it.
+        state["last_span_context"] = span.get_span_context()
         conversation_store.save(conversation_id, state)
         logger.info(
             "Chat turn complete: conversation_id=%s current_agent=%s messages=%d events=%d",

--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -60,20 +60,33 @@ tracer = trace.get_tracer("openai-agents")
 # =========================
 # Each chat turn arrives as its own request and therefore its own trace. To stitch
 # a whole conversation back together we (1) set a stable gen_ai.conversation.id on
-# the turn's root span, (2) publish it to OTel baggage in /chat so the agent/model/
-# tool child spans created by the Agents SDK + Traceloop inherit it (via the span
-# processor below), and (3) link each turn's trace to the previous turn's.
-from opentelemetry import baggage, context as otel_context
+# the turn's root span, (2) stamp that same id onto the agent/model/tool child spans
+# created by the Agents SDK + Traceloop, and (3) link each turn's trace to the
+# previous turn's.
+#
+# The whole turn runs in one process, so (2) only needs *in-process* propagation:
+# a contextvar set in /chat, read by the span processor below at span start. No OTel
+# baggage — baggage carries values across service boundaries (into outgoing request
+# headers), which this single service neither needs nor should leak to third parties.
+import contextvars
+
 from opentelemetry.sdk.trace import SpanProcessor as _SpanProcessor
 
 GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id"
 
+# Holds the current turn's conversation id for the span processor to read. contextvars
+# propagate to the same async task and its awaited coroutines, so the spans the Agents
+# SDK opens during Runner.run inherit it.
+_conversation_id_var: contextvars.ContextVar = contextvars.ContextVar(
+    "gen_ai_conversation_id", default=None
+)
+
 
 class _ConversationIdSpanProcessor(_SpanProcessor):
-    """Stamp gen_ai.conversation.id from baggage onto every span at start."""
+    """Stamp gen_ai.conversation.id from the contextvar onto every span at start."""
 
     def on_start(self, span, parent_context=None):
-        conv_id = baggage.get_baggage(GEN_AI_CONVERSATION_ID, parent_context)
+        conv_id = _conversation_id_var.get()
         if conv_id:
             span.set_attribute(GEN_AI_CONVERSATION_ID, conv_id)
 
@@ -330,11 +343,9 @@ async def chat_endpoint(req: ChatRequest):
         old_context = state["context"].model_dump().copy()
         guardrail_checks: List[GuardrailCheck] = []
 
-        # Publish the conversation id to baggage so every child span created during
-        # the agent run (model calls, tool calls, guardrails) inherits it.
-        _conv_token = otel_context.attach(
-            baggage.set_baggage(GEN_AI_CONVERSATION_ID, conversation_id)
-        )
+        # Make the conversation id visible in-process so every child span created
+        # during the agent run (model calls, tool calls, guardrails) inherits it.
+        _conv_token = _conversation_id_var.set(conversation_id)
         try:
             result = await Runner.run(current_agent, state["input_items"], context=state["context"])
         except InputGuardrailTripwireTriggered as e:
@@ -370,7 +381,7 @@ async def chat_endpoint(req: ChatRequest):
                 guardrails=guardrail_checks,
             )
         finally:
-            otel_context.detach(_conv_token)
+            _conversation_id_var.reset(_conv_token)
 
         messages: List[MessageResponse] = []
         events: List[AgentEvent] = []

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -3,12 +3,14 @@ package e2e
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // runMakeTarget runs a Makefile target in the given app directory (e.g. "request"
@@ -268,12 +270,29 @@ func triggerMCPAgent(t *testing.T) {
 	}
 }
 
-// triggerCSAgent POSTs an airline question to /chat on localhost:8000.
-func triggerCSAgent(t *testing.T) {
+// triggerCSAgent POSTs two airline questions to /chat on localhost:8000, reusing
+// the same conversation_id. Each turn is its own request and therefore its own
+// trace, so two turns are what exercise cross-trace stitching via
+// gen_ai.conversation.id (and the previous-turn span link). Returns the shared
+// conversation id so the caller can assert the turns stitched together.
+func triggerCSAgent(t *testing.T) string {
+	t.Helper()
+
+	conversationID := fmt.Sprintf("e2e-cs-%d", time.Now().UnixNano())
+	postCSTurn(t, conversationID, "What is the baggage allowance for economy class?")
+	postCSTurn(t, conversationID, "And can I change my seat to a window seat?")
+	return conversationID
+}
+
+// postCSTurn POSTs a single chat turn for the given conversation to /chat.
+func postCSTurn(t *testing.T, conversationID, message string) {
 	t.Helper()
 	const url = "http://127.0.0.1:8000/chat"
 
-	b, _ := json.Marshal(map[string]string{"message": "What is the baggage allowance for economy class?"})
+	b, _ := json.Marshal(map[string]string{
+		"conversation_id": conversationID,
+		"message":         message,
+	})
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
 	if err != nil {
 		t.Fatalf("build request: %v", err)

--- a/test/e2e/openai_agents_opentelemetry_test.go
+++ b/test/e2e/openai_agents_opentelemetry_test.go
@@ -3,6 +3,7 @@ package e2e
 import (
 	"fmt"
 	"testing"
+	"time"
 )
 
 func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
@@ -20,12 +21,16 @@ func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
 	// The two turns share one conversation_id but land in separate traces. Assert
 	// that gen_ai.conversation.id stitches them: one conversation spanning >= 2
 	// traces. This only passes if the app stamps conversation.id on the spans.
-	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
-		fmt.Sprintf(`fetch spans, from: now()-10m
+	//
+	// This is a plain existence assertion, not an auditSpan call: the query ends in
+	// a summarize, so its single record holds only `traces` — no trace.id and no
+	// gen_ai.* attributes. Feeding that to auditSpan made every required check fail
+	// and overwrote the real (PASS) report for this suite, since both audits share
+	// the reports/openai-agents-opentelemetry.{json,md} filename.
+	assertSpanExistsWithin(t, scopedDQL(fmt.Sprintf(`fetch spans, from: now()-10m
 | filter service.name == "openai-cs-agents"
 | filter gen_ai.conversation.id == "%s"
 | summarize traces = countDistinct(trace.id)
 | filter traces >= 2
-| limit 1`, conversationID),
-		"multi-turn conversation stitched across traces via gen_ai.conversation.id")
+| limit 1`, conversationID)), 5*time.Minute)
 }

--- a/test/e2e/openai_agents_opentelemetry_test.go
+++ b/test/e2e/openai_agents_opentelemetry_test.go
@@ -1,12 +1,13 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
 	startApp(t, "openai-agents/opentelemetry")
-	triggerCSAgent(t)
+	conversationID := triggerCSAgent(t)
 
 	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
 		`fetch spans, from: now()-10m
@@ -15,4 +16,16 @@ func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
 | filter isNotNull(gen_ai.request.model)
 | filter isNull(span.status_code) or span.status_code != "error"
 | limit 1`)
+
+	// The two turns share one conversation_id but land in separate traces. Assert
+	// that gen_ai.conversation.id stitches them: one conversation spanning >= 2
+	// traces. This only passes if the app stamps conversation.id on the spans.
+	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
+		fmt.Sprintf(`fetch spans, from: now()-10m
+| filter service.name == "openai-cs-agents"
+| filter gen_ai.conversation.id == "%s"
+| summarize traces = countDistinct(trace.id)
+| filter traces >= 2
+| limit 1`, conversationID),
+		"multi-turn conversation stitched across traces via gen_ai.conversation.id")
 }


### PR DESCRIPTION
## What

Makes the `openai-cs-agents` demo follow the OpenTelemetry convention for stitching an **agentic, multi-turn conversation** back together across spans and traces, and updates the e2e test to actually exercise it.

Each chat turn is its own request and therefore its own trace. Within a turn, `trace.id`/`parent_span_id` already stitch the agent/model/tool spans. Across turns, nothing tied them together: the demo kept a `conversation_id` in app state but **never emitted it to telemetry**, and even discarded a caller-supplied id, so two turns never shared one id. The e2e test also only fired a single turn.

## App changes (`openai-agents/opentelemetry/api.py`)

1. **Honor a caller-supplied `conversation_id`** (mint only when absent) so a client can keep one stable id across turns. Previously an unknown caller id was replaced per turn, so turns never stitched.
2. **Stamp `gen_ai.conversation.id` on the turn's root `/chat` span.**
3. **Propagate it in-process to the child spans** via a `contextvar` read by a small `SpanProcessor` at span start — so the id is on every span of the turn (agent, model, tool, guardrail, handoff), not just the root. (Deliberately **not** OTel baggage: this is a single service, so child spans only need in-process propagation; baggage would push the id into outgoing request headers to third parties for no benefit.)
4. **Span link from each turn's trace back to the previous turn's root span** (`gen_ai.conversation.link=previous_turn`), tracked via conversation state.

## e2e changes (`test/e2e/`)

- `triggerCSAgent` now posts **two** `/chat` turns reusing **one** `conversation_id` and returns it.
- Added an assertion that `gen_ai.conversation.id` ties one conversation across **>= 2 traces** — which only passes once the app honors + stamps the id.

This assertion uses `assertSpanExistsWithin`, **not** `auditSpan`. It was first written as a second `auditSpan` call, which was wrong: the query ends in `| summarize traces = countDistinct(trace.id)`, so its single record holds only `traces` — no `trace.id` and no `gen_ai.*` attributes. `fetchTraceSpans` fell back to anchor-only and `buildReport` marked every required attribute (AR-001…AR-007, including `service.name`) as failed, then **overwrote the genuine PASS report** for this suite, since both audits share the `reports/openai-agents-opentelemetry.{json,md}` filename. CI stayed green throughout because `auditSpan` only logs attribute gaps. The assertion keeps identical strength — a `traces >= 2` summarize returning zero rows still fails the test — it just no longer pretends to be a span audit.

Worth knowing more generally: `auditSpan` is only valid for DQL returning raw span records, and two `auditSpan` calls in one suite clobber each other's report file (the Bedrock guardrail audit works around this by suffixing the instrumentation name).

## What this does and doesn't buy today

Scoping this deliberately, because "queryable by conversation" oversells it. Checked against `genai-observability`:

- **Within a single turn there is no difference between filtering on `trace.id` and on `gen_ai.conversation.id`** — one turn is one trace, so both select the same spans. The keys only diverge across turns.
- The app has a working **Conversation ID filter** on the Prompts page (`Prompts.constants.ts:311`), and shows the id in the span details Identifiers group.
- But the **Conversation ID column has `perspectives: []`** (`Prompts.constants.ts:242`), so it appears in no default view; the **Agentic page's conversation count is a hardcoded placeholder** (`getNodesSummary.ts:20`, `239 // TODO: Add when data available`); and there is **no conversation-level grouping or stitched multi-turn timeline** — the trace waterfall is per-trace by construction.

So the payoff here is cross-trace **filtering** plus a stable **eval unit** for multi-turn evaluation (which `trace.id` cannot provide by construction) — not a new conversation view in the UI.

## Verified

Two turns with one id → `traces = 2`, `spans = 34`, all spans carrying the id, turn 2 linked to turn 1.

Caveat: that run predates both the baggage→contextvar swap and the audit-assertion fix above. The swap is semantically equivalent (contextvars flow to the same async task and its awaited coroutines) but the suite has **not yet been re-run green** on the current head.

## Out of scope

Agent identity (`gen_ai.agent.name` / `gen_ai.agent.id`) is untouched — `agent.name` is already emitted here (Triage / FAQ / Seat Booking Agents + guardrails), and `agent.id` doesn't apply (no hosted agent resource; the spec wants a *stable* resource id these in-process agents don't have).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

