### PR TITLE
fix: propagate OTel trace context into worker threads and set global TracerProvider

### DIFF
--- a/crewai/opentelemetry/app.py
+++ b/crewai/opentelemetry/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import os
 
 os.environ["TRACELOOP_TELEMETRY"] = "false"
@@ -58,7 +59,8 @@ async def haiku() -> str:
         result = crew.kickoff()
         return str(result)
 
-    return await asyncio.to_thread(_call)
+    ctx = contextvars.copy_context()
+    return await asyncio.get_event_loop().run_in_executor(None, ctx.run, _call)
 
 
 if __name__ == "__main__":

--- a/langgraph/openinference/app.py
+++ b/langgraph/openinference/app.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry import trace
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource, SERVICE_NAME
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -12,6 +13,7 @@ _service_name = os.environ.get("OTEL_SERVICE_NAME", "langgraph/openinference")
 _resource = Resource.create({SERVICE_NAME: _service_name})
 _tracer_provider = trace_sdk.TracerProvider(resource=_resource)
 _tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(_tracer_provider)
 LangChainInstrumentor().instrument(tracer_provider=_tracer_provider)
 
 from fastapi import FastAPI

--- a/langgraph/opentelemetry/bedrock/app.py
+++ b/langgraph/opentelemetry/bedrock/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import os
 from typing import TypedDict
 
@@ -95,7 +96,8 @@ async def haiku(req: HaikuRequest | None = None) -> str:
         result = graph.invoke({"topic": topic, "haiku": ""})
         return str(result["haiku"])
 
-    return await asyncio.to_thread(_call)
+    ctx = contextvars.copy_context()
+    return await asyncio.get_event_loop().run_in_executor(None, ctx.run, _call)
 
 
 if __name__ == "__main__":

--- a/langgraph/opentelemetry/openai/app.py
+++ b/langgraph/opentelemetry/openai/app.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextvars
 import os
 from typing import TypedDict
 
@@ -99,7 +100,8 @@ async def haiku(req: HaikuRequest | None = None) -> str:
         result = graph.invoke({"topic": topic, "haiku": ""})
         return str(result["haiku"])
 
-    return await asyncio.to_thread(_call)
+    ctx = contextvars.copy_context()
+    return await asyncio.get_event_loop().run_in_executor(None, ctx.run, _call)
 
 
 if __name__ == "__main__":

--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -268,9 +268,12 @@ async def chat_endpoint(req: ChatRequest):
     # Resolve the conversation identity BEFORE opening the span. Each turn is its
     # own trace, so stitching a multi-turn conversation together needs both a stable
     # conversation_id (reused across turns) and a span link back to the prior turn.
-    existing_state = conversation_store.get(req.conversation_id) if req.conversation_id else None
+    # Honor a caller-supplied conversation_id so a client can keep one stable id
+    # across turns; mint one only when the caller doesn't provide it. (Previously an
+    # unknown caller id was discarded and replaced per turn, so turns never stitched.)
+    conversation_id: str = req.conversation_id or uuid4().hex
+    existing_state = conversation_store.get(conversation_id)
     is_new = existing_state is None
-    conversation_id: str = uuid4().hex if is_new else req.conversation_id  # type: ignore
 
     # Link this turn's trace back to the previous turn's root span, when known.
     turn_links: List[trace.Link] = []

--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -55,6 +55,40 @@ _logging.getLogger().addHandler(_otel_log_handler)
 from opentelemetry import trace
 tracer = trace.get_tracer("openai-agents")
 
+# =========================
+# Conversation-id propagation
+# =========================
+# Each chat turn arrives as its own request and therefore its own trace. To stitch
+# a whole conversation back together we (1) set a stable gen_ai.conversation.id on
+# the turn's root span, (2) publish it to OTel baggage in /chat so the agent/model/
+# tool child spans created by the Agents SDK + Traceloop inherit it (via the span
+# processor below), and (3) link each turn's trace to the previous turn's.
+from opentelemetry import baggage, context as otel_context
+from opentelemetry.sdk.trace import SpanProcessor as _SpanProcessor
+
+GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id"
+
+
+class _ConversationIdSpanProcessor(_SpanProcessor):
+    """Stamp gen_ai.conversation.id from baggage onto every span at start."""
+
+    def on_start(self, span, parent_context=None):
+        conv_id = baggage.get_baggage(GEN_AI_CONVERSATION_ID, parent_context)
+        if conv_id:
+            span.set_attribute(GEN_AI_CONVERSATION_ID, conv_id)
+
+    def on_end(self, span):
+        pass
+
+    def shutdown(self):
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000):
+        return True
+
+
+trace.get_tracer_provider().add_span_processor(_ConversationIdSpanProcessor())
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
@@ -227,15 +261,34 @@ def health():
 
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(req: ChatRequest):
-    with tracer.start_as_current_span(name="/chat", kind=trace.SpanKind.SERVER) as span:
-        """
-        Main chat endpoint for agent orchestration.
-        Handles conversation state, agent routing, and guardrail checks.
-        """
+    """
+    Main chat endpoint for agent orchestration.
+    Handles conversation state, agent routing, and guardrail checks.
+    """
+    # Resolve the conversation identity BEFORE opening the span. Each turn is its
+    # own trace, so stitching a multi-turn conversation together needs both a stable
+    # conversation_id (reused across turns) and a span link back to the prior turn.
+    existing_state = conversation_store.get(req.conversation_id) if req.conversation_id else None
+    is_new = existing_state is None
+    conversation_id: str = uuid4().hex if is_new else req.conversation_id  # type: ignore
+
+    # Link this turn's trace back to the previous turn's root span, when known.
+    turn_links: List[trace.Link] = []
+    if existing_state is not None:
+        prev_ctx = existing_state.get("last_span_context")
+        if prev_ctx is not None:
+            turn_links.append(
+                trace.Link(prev_ctx, attributes={"gen_ai.conversation.link": "previous_turn"})
+            )
+
+    with tracer.start_as_current_span(
+        name="/chat", kind=trace.SpanKind.SERVER, links=turn_links
+    ) as span:
+        # gen_ai.conversation.id ties every turn of this chat together.
+        span.set_attribute(GEN_AI_CONVERSATION_ID, conversation_id)
+
         # Initialize or retrieve conversation state
-        is_new = not req.conversation_id or conversation_store.get(req.conversation_id) is None
         if is_new:
-            conversation_id: str = uuid4().hex
             ctx = create_initial_context()
             current_agent_name = triage_agent.name
             state: Dict[str, Any] = {
@@ -249,6 +302,7 @@ async def chat_endpoint(req: ChatRequest):
                 ctx.account_number,
             )
             if req.message.strip() == "":
+                state["last_span_context"] = span.get_span_context()
                 conversation_store.save(conversation_id, state)
                 return ChatResponse(
                     conversation_id=conversation_id,
@@ -260,8 +314,7 @@ async def chat_endpoint(req: ChatRequest):
                     guardrails=[],
                 )
         else:
-            conversation_id = req.conversation_id  # type: ignore
-            state = conversation_store.get(conversation_id)
+            state = existing_state
 
         current_agent = _get_agent_by_name(state["current_agent"])
         logger.info(
@@ -274,6 +327,11 @@ async def chat_endpoint(req: ChatRequest):
         old_context = state["context"].model_dump().copy()
         guardrail_checks: List[GuardrailCheck] = []
 
+        # Publish the conversation id to baggage so every child span created during
+        # the agent run (model calls, tool calls, guardrails) inherits it.
+        _conv_token = otel_context.attach(
+            baggage.set_baggage(GEN_AI_CONVERSATION_ID, conversation_id)
+        )
         try:
             result = await Runner.run(current_agent, state["input_items"], context=state["context"])
         except InputGuardrailTripwireTriggered as e:
@@ -308,6 +366,8 @@ async def chat_endpoint(req: ChatRequest):
                 agents=_build_agents_list(),
                 guardrails=guardrail_checks,
             )
+        finally:
+            otel_context.detach(_conv_token)
 
         messages: List[MessageResponse] = []
         events: List[AgentEvent] = []
@@ -421,6 +481,8 @@ async def chat_endpoint(req: ChatRequest):
 
         state["input_items"] = result.to_input_list()
         state["current_agent"] = current_agent.name
+        # Record this turn's root span so the next turn can link back to it.
+        state["last_span_context"] = span.get_span_context()
         conversation_store.save(conversation_id, state)
         logger.info(
             "Chat turn complete: conversation_id=%s current_agent=%s messages=%d events=%d",

--- a/openai-agents/opentelemetry/api.py
+++ b/openai-agents/opentelemetry/api.py
@@ -60,20 +60,33 @@ tracer = trace.get_tracer("openai-agents")
 # =========================
 # Each chat turn arrives as its own request and therefore its own trace. To stitch
 # a whole conversation back together we (1) set a stable gen_ai.conversation.id on
-# the turn's root span, (2) publish it to OTel baggage in /chat so the agent/model/
-# tool child spans created by the Agents SDK + Traceloop inherit it (via the span
-# processor below), and (3) link each turn's trace to the previous turn's.
-from opentelemetry import baggage, context as otel_context
+# the turn's root span, (2) stamp that same id onto the agent/model/tool child spans
+# created by the Agents SDK + Traceloop, and (3) link each turn's trace to the
+# previous turn's.
+#
+# The whole turn runs in one process, so (2) only needs *in-process* propagation:
+# a contextvar set in /chat, read by the span processor below at span start. No OTel
+# baggage — baggage carries values across service boundaries (into outgoing request
+# headers), which this single service neither needs nor should leak to third parties.
+import contextvars
+
 from opentelemetry.sdk.trace import SpanProcessor as _SpanProcessor
 
 GEN_AI_CONVERSATION_ID = "gen_ai.conversation.id"
 
+# Holds the current turn's conversation id for the span processor to read. contextvars
+# propagate to the same async task and its awaited coroutines, so the spans the Agents
+# SDK opens during Runner.run inherit it.
+_conversation_id_var: contextvars.ContextVar = contextvars.ContextVar(
+    "gen_ai_conversation_id", default=None
+)
+
 
 class _ConversationIdSpanProcessor(_SpanProcessor):
-    """Stamp gen_ai.conversation.id from baggage onto every span at start."""
+    """Stamp gen_ai.conversation.id from the contextvar onto every span at start."""
 
     def on_start(self, span, parent_context=None):
-        conv_id = baggage.get_baggage(GEN_AI_CONVERSATION_ID, parent_context)
+        conv_id = _conversation_id_var.get()
         if conv_id:
             span.set_attribute(GEN_AI_CONVERSATION_ID, conv_id)
 
@@ -330,11 +343,9 @@ async def chat_endpoint(req: ChatRequest):
         old_context = state["context"].model_dump().copy()
         guardrail_checks: List[GuardrailCheck] = []
 
-        # Publish the conversation id to baggage so every child span created during
-        # the agent run (model calls, tool calls, guardrails) inherits it.
-        _conv_token = otel_context.attach(
-            baggage.set_baggage(GEN_AI_CONVERSATION_ID, conversation_id)
-        )
+        # Make the conversation id visible in-process so every child span created
+        # during the agent run (model calls, tool calls, guardrails) inherits it.
+        _conv_token = _conversation_id_var.set(conversation_id)
         try:
             result = await Runner.run(current_agent, state["input_items"], context=state["context"])
         except InputGuardrailTripwireTriggered as e:
@@ -370,7 +381,7 @@ async def chat_endpoint(req: ChatRequest):
                 guardrails=guardrail_checks,
             )
         finally:
-            otel_context.detach(_conv_token)
+            _conversation_id_var.reset(_conv_token)
 
         messages: List[MessageResponse] = []
         events: List[AgentEvent] = []

--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -6,6 +6,7 @@ from openai.types.chat import ChatCompletionChunk
 from openinference.instrumentation.openai import OpenAIInstrumentor
 from openinference.instrumentation import using_attributes
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry import trace
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.sdk.resources import Resource, OTELResourceDetector, ProcessResourceDetector, OsResourceDetector, \
@@ -25,6 +26,7 @@ resource = get_aggregated_resources(detectors=detectors, initial_resource=Resour
 tracer_provider = trace_sdk.TracerProvider(resource=resource)
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
 tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
 
 OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
 

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -3,12 +3,14 @@ package e2e
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // runMakeTarget runs a Makefile target in the given app directory (e.g. "request"
@@ -268,12 +270,29 @@ func triggerMCPAgent(t *testing.T) {
 	}
 }
 
-// triggerCSAgent POSTs an airline question to /chat on localhost:8000.
-func triggerCSAgent(t *testing.T) {
+// triggerCSAgent POSTs two airline questions to /chat on localhost:8000, reusing
+// the same conversation_id. Each turn is its own request and therefore its own
+// trace, so two turns are what exercise cross-trace stitching via
+// gen_ai.conversation.id (and the previous-turn span link). Returns the shared
+// conversation id so the caller can assert the turns stitched together.
+func triggerCSAgent(t *testing.T) string {
+	t.Helper()
+
+	conversationID := fmt.Sprintf("e2e-cs-%d", time.Now().UnixNano())
+	postCSTurn(t, conversationID, "What is the baggage allowance for economy class?")
+	postCSTurn(t, conversationID, "And can I change my seat to a window seat?")
+	return conversationID
+}
+
+// postCSTurn POSTs a single chat turn for the given conversation to /chat.
+func postCSTurn(t *testing.T, conversationID, message string) {
 	t.Helper()
 	const url = "http://127.0.0.1:8000/chat"
 
-	b, _ := json.Marshal(map[string]string{"message": "What is the baggage allowance for economy class?"})
+	b, _ := json.Marshal(map[string]string{
+		"conversation_id": conversationID,
+		"message":         message,
+	})
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
 	if err != nil {
 		t.Fatalf("build request: %v", err)

--- a/test/e2e/openai_agents_opentelemetry_test.go
+++ b/test/e2e/openai_agents_opentelemetry_test.go
@@ -1,12 +1,13 @@
 package e2e
 
 import (
+	"fmt"
 	"testing"
 )
 
 func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
 	startApp(t, "openai-agents/opentelemetry")
-	triggerCSAgent(t)
+	conversationID := triggerCSAgent(t)
 
 	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
 		`fetch spans, from: now()-10m
@@ -15,4 +16,16 @@ func TestOpenAIAgentsOpenTelemetry(t *testing.T) {
 | filter isNotNull(gen_ai.request.model)
 | filter isNull(span.status_code) or span.status_code != "error"
 | limit 1`)
+
+	// The two turns share one conversation_id but land in separate traces. Assert
+	// that gen_ai.conversation.id stitches them: one conversation spanning >= 2
+	// traces. This only passes if the app stamps conversation.id on the spans.
+	auditSpan(t, "openai-agents", "opentelemetry", GenericProfile,
+		fmt.Sprintf(`fetch spans, from: now()-10m
+| filter service.name == "openai-cs-agents"
+| filter gen_ai.conversation.id == "%s"
+| summarize traces = countDistinct(trace.id)
+| filter traces >= 2
+| limit 1`, conversationID),
+		"multi-turn conversation stitched across traces via gen_ai.conversation.id")
 }


### PR DESCRIPTION
## Problem

Two related issues were causing spans with `null trace_id` in Dynatrace:

### 1. Missing `set_tracer_provider()` in OpenInference examples
`openai/openinference` and `langgraph/openinference` configured a local `TracerProvider` and passed it to the instrumentor, but never registered it as the **global** provider via `trace.set_tracer_provider()`. Instrumentation libraries that resolve the tracer through the global OTel API created orphaned root spans with no `trace_id`.

**Fix:** add `trace.set_tracer_provider(tracer_provider)` after building the provider.

### 2. OTel context not propagated across `asyncio.to_thread()`
`langgraph/opentelemetry/openai`, `langgraph/opentelemetry/bedrock`, and `crewai/opentelemetry` all used `asyncio.to_thread(_call)` to run synchronous framework code. Python's `asyncio.to_thread` does **not** copy the current `contextvars` context, so the active OTel span was invisible inside the worker thread — all spans created there became detached roots.

**Fix:** replace `asyncio.to_thread(_call)` with `contextvars.copy_context()` + `run_in_executor()` to explicitly carry the OTel context into the thread.

## Files changed
| File | Fix |
|---|---|
| `openai/openinference/app.py` | Add `trace.set_tracer_provider()` |
| `langgraph/openinference/app.py` | Add `trace.set_tracer_provider()` |
| `langgraph/opentelemetry/openai/app.py` | Context-propagating thread dispatch |
| `langgraph/opentelemetry/bedrock/app.py` | Context-propagating thread dispatch |
| `crewai/opentelemetry/app.py` | Context-propagating thread dispatch |