### PR TITLE
fix: register the openinference tracer providers globally

### DIFF
--- a/langgraph/openinference/app.py
+++ b/langgraph/openinference/app.py
@@ -4,6 +4,7 @@ from typing import TypedDict
 
 from openinference.instrumentation.langchain import LangChainInstrumentor
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry import trace
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.resources import Resource, SERVICE_NAME
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
@@ -12,6 +13,7 @@ _service_name = os.environ.get("OTEL_SERVICE_NAME", "langgraph/openinference")
 _resource = Resource.create({SERVICE_NAME: _service_name})
 _tracer_provider = trace_sdk.TracerProvider(resource=_resource)
 _tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
+trace.set_tracer_provider(_tracer_provider)
 LangChainInstrumentor().instrument(tracer_provider=_tracer_provider)
 
 from fastapi import FastAPI

--- a/openai/openinference/app.py
+++ b/openai/openinference/app.py
@@ -6,6 +6,7 @@ from openai.types.chat import ChatCompletionChunk
 from openinference.instrumentation.openai import OpenAIInstrumentor
 from openinference.instrumentation import using_attributes
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry import trace
 from opentelemetry.sdk import trace as trace_sdk
 from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
 from opentelemetry.sdk.resources import Resource, OTELResourceDetector, ProcessResourceDetector, OsResourceDetector, \
@@ -25,6 +26,7 @@ resource = get_aggregated_resources(detectors=detectors, initial_resource=Resour
 tracer_provider = trace_sdk.TracerProvider(resource=resource)
 tracer_provider.add_span_processor(SimpleSpanProcessor(OTLPSpanExporter()))
 tracer_provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter()))
+trace.set_tracer_provider(tracer_provider)
 
 OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
 


### PR DESCRIPTION
## Problem

`openai/openinference` and `langgraph/openinference` each build a local `TracerProvider`, attach the OTLP exporter to it, and pass it to the instrumentor — but never call `trace.set_tracer_provider()`.

Anything that resolves its tracer through the **global** OTel API therefore gets a different provider than the one carrying the exporter, so those spans are never exported.

**Fix:** call `trace.set_tracer_provider(tracer_provider)` after building the provider.

| File | Change |
|---|---|
| `openai/openinference/app.py` | `trace.set_tracer_provider(...)` + import |
| `langgraph/openinference/app.py` | `trace.set_tracer_provider(...)` + import |

## Corrections to the original version of this PR

This PR previously claimed to fix "spans with `null trace_id` in Dynatrace" and included a second, unrelated fix. Both claims were wrong and have been removed.

**1. The `null trace_id` premise was a query artifact.** It came from a DQL query filtering on `trace_id` instead of `trace.id`. Unknown fields evaluate to null in DQL, so `isNull(trace_id)` matched *every* record — the result was never an orphan list. Measured afterwards: `trace.id` is populated on **100%** of spans across all 12 OneAgent services, every trace is **single-rooted** (`multi_root = 0`, `zero_root = 0`), and there are **no orphaned spans**.

The symptom of the bug this PR *does* fix is **missing spans**, not spans with a null trace id.

**2. The `asyncio.to_thread` rewrites were a no-op and have been reverted.** The claim was that `asyncio.to_thread` does not copy the current `contextvars` context, detaching OTel spans created in the worker thread. That is false — `to_thread` has propagated the current `contextvars.Context` since Python 3.9. Verified directly:

```
asyncio.to_thread            -> SET-IN-EVENT-LOOP
copy_context+run_in_executor -> SET-IN-EVENT-LOOP
```

Both forms see the value, so the OTel span was never invisible in those threads. The rewrite was behaviourally identical to what `to_thread` already does internally, and additionally reintroduced the deprecated `asyncio.get_event_loop()` (correct call inside a coroutine is `get_running_loop()`). Reverted in `crewai/opentelemetry`, `langgraph/opentelemetry/openai`, and `langgraph/opentelemetry/bedrock`.

## Note on the base branch

This branch is stacked on `openai-cs-agents-conversation-stitching` (#219), so it is targeted at that branch rather than `main` and shows only its own 4-line diff. GitHub will retarget it to `main` automatically when #219 merges.

It was previously targeted at `main` while stacked on a pre-fix commit of #219, which meant merging it would have reintroduced the broken span-audit assertion that #219 fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
