### PR TITLE
AI-352: rename the deprecated spanmetrics connector alias to span_metrics

### DIFF
--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -46,7 +46,7 @@ processors:
 connectors:
   # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
   # from the LLM span durations — same connector the langfuse demo uses.
-  spanmetrics:
+  span_metrics:
     namespace: gen_ai.client.operation
     # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
@@ -100,7 +100,7 @@ connectors:
           - key: gen_ai.provider.name
           - key: gen_ai.operation.name
       # service.name is a resource attribute included by default — no
-      # include_resource_attributes filter needed, same as spanmetrics.
+      # include_resource_attributes filter needed, same as span_metrics.
 
 exporters:
   otlp_http/dynatrace:
@@ -120,9 +120,9 @@ service:
     traces/genai_metrics:
       receivers: [otlp]
       processors: [gen_ai_normalizer, transform/response_model, filter/genai_only, batch]
-      exporters: [spanmetrics, signal_to_metrics]
+      exporters: [span_metrics, signal_to_metrics]
     metrics:
-      receivers: [otlp, spanmetrics, signal_to_metrics]
+      receivers: [otlp, span_metrics, signal_to_metrics]
       exporters: [otlp_http/dynatrace]
     logs:
       receivers: [otlp]

--- a/langfuse/opentelemetry-node/README.md
+++ b/langfuse/opentelemetry-node/README.md
@@ -41,7 +41,7 @@ make run-openpipeline   # direct to Dynatrace — OpenPipeline transforms on ing
 Node.js app → OTLP → Bindplane Collector → (transform) → Dynatrace
 ```
 
-Collector config: `../opentelemetry/otel-collector-config.yaml`. A `spanmetrics` connector in that config derives `gen_ai.client.operation.duration` from the LLM span durations, and a `signal_to_metrics` connector derives `gen_ai.client.token.usage` from `gen_ai.usage.input_tokens` / `output_tokens` — both exported to Dynatrace (needs the token's `metrics.ingest` scope). The OpenPipeline path produces the same two metrics server-side via metric-extraction processors.
+Collector config: `../opentelemetry/otel-collector-config.yaml`. A `span_metrics` connector in that config derives `gen_ai.client.operation.duration` from the LLM span durations, and a `signal_to_metrics` connector derives `gen_ai.client.token.usage` from `gen_ai.usage.input_tokens` / `output_tokens` — both exported to Dynatrace (needs the token's `metrics.ingest` scope). The OpenPipeline path produces the same two metrics server-side via metric-extraction processors.
 
 > **Note:** this runs the [Bindplane collector](https://github.com/observIQ/bindplane-agent), not the Dynatrace distribution -- `signal_to_metrics` isn't compiled into `ghcr.io/dynatrace/dynatrace-otel-collector` as of its latest release (checked v0.52.0).
 

--- a/langfuse/opentelemetry/README.md
+++ b/langfuse/opentelemetry/README.md
@@ -50,7 +50,7 @@ Langfuse uses its own semantic conventions that the Dynatrace AI Observability a
 | **Good for** | Full control over the pipeline, works anywhere you can run a collector | Simpler ops -- no collector to manage |
 | **Make target** | `make run` | `make run-openpipeline` (deploy once first) |
 
-Both paths produce the same `gen_ai.*` span attributes, and both emit the `gen_ai.client.operation.duration` and `gen_ai.client.token.usage` metrics charted by the AI Observability app -- Option A via the collector's `spanmetrics` and `signal_to_metrics` connectors, Option B via OpenPipeline metric-extraction processors (see [Attribute mapping reference](#attribute-mapping-reference)).
+Both paths produce the same `gen_ai.*` span attributes, and both emit the `gen_ai.client.operation.duration` and `gen_ai.client.token.usage` metrics charted by the AI Observability app -- Option A via the collector's `span_metrics` and `signal_to_metrics` connectors, Option B via OpenPipeline metric-extraction processors (see [Attribute mapping reference](#attribute-mapping-reference)).
 
 ---
 
@@ -105,7 +105,7 @@ App  →  Langfuse SDK (OTLP export)  →  Bindplane Collector (transform proces
 make run
 ```
 
-The collector listens on port `4318`. The `transform/langfuse` processor maps `langfuse.observation.*` attributes to `gen_ai.*` before forwarding to Dynatrace. A second pipeline branch feeds `spanmetrics` (derives `gen_ai.client.operation.duration`, seconds, from LLM span durations) and `signal_to_metrics` (derives `gen_ai.client.token.usage` from the `gen_ai.usage.input_tokens` / `output_tokens` attributes), both exported to Dynatrace. The collector stays running after the app exits so the metrics flush; stop it with `make stop`.
+The collector listens on port `4318`. The `transform/langfuse` processor maps `langfuse.observation.*` attributes to `gen_ai.*` before forwarding to Dynatrace. A second pipeline branch feeds `span_metrics` (derives `gen_ai.client.operation.duration`, seconds, from LLM span durations) and `signal_to_metrics` (derives `gen_ai.client.token.usage` from the `gen_ai.usage.input_tokens` / `output_tokens` attributes), both exported to Dynatrace. The collector stays running after the app exits so the metrics flush; stop it with `make stop`.
 
 > **Note:** this runs the [Bindplane collector](https://github.com/observIQ/bindplane-agent), not the Dynatrace distribution -- `signal_to_metrics` isn't compiled into `ghcr.io/dynatrace/dynatrace-otel-collector` as of its latest release (checked v0.52.0).
 
@@ -184,7 +184,7 @@ These mappings are applied by both the Bindplane Collector (`transform/langfuse`
 
 | Metric | Source | Notes |
 |---|---|---|
-| `gen_ai.client.operation.duration` | LLM span duration | Charted by the AI Observability app. Option A (Collector) emits it via the `spanmetrics` connector; Option B (OpenPipeline) extracts it with a `samplingAwareHistogramMetric` processor (`measurement: field`, seconds). Both carry `service.name` as a dimension. OpenPipeline metric extraction from spans requires the DPS **Metrics Ingest and Process** rate card. |
+| `gen_ai.client.operation.duration` | LLM span duration | Charted by the AI Observability app. Option A (Collector) emits it via the `span_metrics` connector; Option B (OpenPipeline) extracts it with a `samplingAwareHistogramMetric` processor (`measurement: field`, seconds). Both carry `service.name` as a dimension. OpenPipeline metric extraction from spans requires the DPS **Metrics Ingest and Process** rate card. |
 | `gen_ai.client.token.usage` | `gen_ai.usage.input_tokens` / `output_tokens` | Charted by the AI Observability app, dimensioned by `gen_ai.token.type` (`input`/`output`). Option A (Collector) emits it via the `signal_to_metrics` connector (two `sum` metric definitions, one per direction, `gen_ai.token.type` set via `default_value` since the span carries no such attribute itself); Option B (OpenPipeline) extracts it with two `samplingAwareValueMetric` processors (same two-extractors-one-metric-key pattern, `gen_ai.token.type` set via a `constant` dimension). |
 
 ---

--- a/langfuse/opentelemetry/otel-collector-config.yaml
+++ b/langfuse/opentelemetry/otel-collector-config.yaml
@@ -102,7 +102,7 @@ processors:
           - delete_key(attributes, "langfuse.observation.type")
 
   # Keep only spans that represent an LLM call (gen_ai.request.model is set by the
-  # transform above on generation/embedding spans). Feeds the spanmetrics connector
+  # transform above on generation/embedding spans). Feeds the span_metrics connector
   # so gen_ai.client.operation.duration covers LLM calls only, not the Langfuse
   # parent/tool spans. Used solely on the metrics branch — the export pipeline is
   # left untouched so all spans still reach Distributed Tracing.
@@ -118,7 +118,7 @@ connectors:
   # Observability app charts. namespace + the connector's "duration" histogram =>
   # gen_ai.client.operation.duration. service.name is a default dimension, so the
   # metric is attributable to the service without a Smartscape lookup.
-  spanmetrics:
+  span_metrics:
     namespace: gen_ai.client.operation
     # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
@@ -135,10 +135,10 @@ connectors:
 
   # Derive gen_ai.client.token.usage (OTel GenAI semconv, "{token}" unit) from the
   # gen_ai.usage.input_tokens / output_tokens attributes the transform above
-  # already normalized. spanmetrics only derives duration/call-count from span
+  # already normalized. span_metrics only derives duration/call-count from span
   # timing, not arbitrary attribute values, so a second connector is needed here.
   # Always emits delta temporality (hardcoded by the connector, same requirement
-  # as spanmetrics above — no config knob for it).
+  # as span_metrics above — no config knob for it).
   #
   # Two entries feed the same metric name, one per token direction — mirroring
   # the "two extractors, one metric key" pattern already used on the OpenPipeline
@@ -179,7 +179,7 @@ connectors:
           - key: gen_ai.response.model
       # service.name is a resource attribute, not a span attribute — it isn't
       # listed above because it's already included by default (no
-      # include_resource_attributes filter is set), same as spanmetrics.
+      # include_resource_attributes filter is set), same as span_metrics.
 
 exporters:
   debug:
@@ -196,12 +196,12 @@ service:
       processors: [attributes/tag_langfuse, transform/langfuse]
       exporters: [debug, otlp_http/dynatrace]
     # Second branch of the same spans: transform, keep only LLM spans, and feed
-    # the spanmetrics + signaltometrics connectors. Kept separate from the export
+    # the span_metrics + signaltometrics connectors. Kept separate from the export
     # pipeline so the filter here never drops spans from Distributed Tracing.
     traces/genai_metrics:
       receivers: [otlp]
       processors: [attributes/tag_langfuse, transform/langfuse, filter/genai_only]
-      exporters: [spanmetrics, signal_to_metrics]
+      exporters: [span_metrics, signal_to_metrics]
     metrics:
-      receivers: [spanmetrics, signal_to_metrics]
+      receivers: [span_metrics, signal_to_metrics]
       exporters: [otlp_http/dynatrace]

--- a/openai/openinference/README.md
+++ b/openai/openinference/README.md
@@ -262,7 +262,7 @@ OpenInference is span-only by design (its instrumentors emit no metric instrumen
 
 | Metric | Option A (collector) | Option B (OpenPipeline) |
 |---|---|---|
-| `gen_ai.client.operation.duration` (s) | `spanmetrics` connector, on LLM spans | `samplingAwareHistogramMetric` extractor on `duration_seconds` |
+| `gen_ai.client.operation.duration` (s) | `span_metrics` connector, on LLM spans | `samplingAwareHistogramMetric` extractor on `duration_seconds` |
 | `gen_ai.client.token.usage` (`gen_ai.token.type` = `input`/`output`) | `signaltometrics` connector, two sum defs | two `samplingAwareValueMetric` extractors, one per direction |
 
 Both read the normalized `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` (mapped from OpenInference's `llm.token_count.*`). **Option A** derives both metrics in the Bindplane collector — `signaltometrics` (token) is bundled there alongside `genainormalizer`; requires the token's `metrics.ingest` scope, and both metrics use delta temporality (Dynatrace rejects cumulative). **Option B** derives the same two metrics server-side via the metric-extraction processors in [`openpipeline-openinference.yaml`](openpipeline-openinference.yaml); the token metric uses the two-extractor pattern (one per direction, both writing `gen_ai.client.token.usage` with a constant `gen_ai.token.type` dimension).

--- a/openai/openinference/otel-collector-config.yaml
+++ b/openai/openinference/otel-collector-config.yaml
@@ -78,7 +78,7 @@ connectors:
   # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
   # from the LLM span durations — same connector the langfuse demo uses. namespace +
   # the connector's "duration" histogram => gen_ai.client.operation.duration.
-  spanmetrics:
+  span_metrics:
     namespace: gen_ai.client.operation
     # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
@@ -133,7 +133,7 @@ connectors:
           - key: gen_ai.provider.name
           - key: gen_ai.operation.name
       # service.name is a resource attribute included by default — no
-      # include_resource_attributes filter needed, same as spanmetrics.
+      # include_resource_attributes filter needed, same as span_metrics.
 
 exporters:
   debug:
@@ -155,7 +155,7 @@ service:
     traces/genai_metrics:
       receivers: [otlp]
       processors: [transform/pre_normalize, gen_ai_normalizer, transform/response_model, filter/genai_only]
-      exporters: [spanmetrics, signal_to_metrics]
+      exporters: [span_metrics, signal_to_metrics]
     metrics:
-      receivers: [spanmetrics, signal_to_metrics]
+      receivers: [span_metrics, signal_to_metrics]
       exporters: [otlp_http/dynatrace]

--- a/pydantic-ai/opentelemetry/Makefile
+++ b/pydantic-ai/opentelemetry/Makefile
@@ -9,7 +9,7 @@ DT_API_TOKEN     ?= dt0c01.*****
 
 # Bindplane Distro for OpenTelemetry (BDOT) collector. v1.104.0 tracks OTel
 # contrib v0.156.0. Used only by `make run-collector` to derive
-# gen_ai.client.operation.duration from spans via the spanmetrics connector.
+# gen_ai.client.operation.duration from spans via the span_metrics connector.
 override COLLECTOR_IMAGE     := ghcr.io/observiq/bindplane-agent:1.105.1
 override COLLECTOR_CONTAINER := otel-collector
 

--- a/pydantic-ai/opentelemetry/backend/otel_setup.py
+++ b/pydantic-ai/opentelemetry/backend/otel_setup.py
@@ -17,7 +17,7 @@ def setup_otel(service_name: str = "pydantic-ai-music-agent"):
     #    duration metric must be backfilled server-side (openpipeline-pydantic-ai.yaml).
     #  - Collector: set OTEL_COLLECTOR_ENDPOINT (e.g. http://localhost:4318) to route
     #    through the local OTel Collector, which derives gen_ai.client.operation.duration
-    #    from the LLM spans (spanmetrics) and forwards everything to Dynatrace. The
+    #    from the LLM spans (span_metrics) and forwards everything to Dynatrace. The
     #    collector holds the DT token, so no Authorization header is sent from the app.
     collector_endpoint = os.environ.get("OTEL_COLLECTOR_ENDPOINT", "").rstrip("/")
 

--- a/pydantic-ai/opentelemetry/otel-collector-config.yaml
+++ b/pydantic-ai/opentelemetry/otel-collector-config.yaml
@@ -12,7 +12,7 @@ processors:
   # Keep only the nested LLM-call spans for the metrics branch. pydantic-ai sets
   # gen_ai.response.model on the model-call spans; the demo's outer
   # "music_agent.ask" wrapper span sets only gen_ai.request.model. Keying on
-  # response.model targets the LLM call alone, so spanmetrics does not also derive
+  # response.model targets the LLM call alone, so span_metrics does not also derive
   # a (wrong, retry-spanning) duration from the wrapper span. The export pipeline
   # is untouched, so all spans still reach Distributed Tracing.
   filter/genai_only:
@@ -25,7 +25,7 @@ connectors:
   # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
   # from the LLM span durations — pydantic-ai emits the token metric natively but
   # NOT this one. Same connector the langfuse demo uses.
-  spanmetrics:
+  span_metrics:
     namespace: gen_ai.client.operation
     # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
     aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
@@ -54,13 +54,13 @@ service:
       receivers: [otlp]
       processors: [batch]
       exporters: [debug, otlp_http/dynatrace]
-    # Second branch: keep only LLM spans and feed the spanmetrics connector.
+    # Second branch: keep only LLM spans and feed the span_metrics connector.
     traces/genai_metrics:
       receivers: [otlp]
       processors: [filter/genai_only, batch]
-      exporters: [spanmetrics]
+      exporters: [span_metrics]
     # pydantic-ai's native gen_ai.client.token.usage arrives on [otlp]; the derived
-    # gen_ai.client.operation.duration arrives on [spanmetrics]. Both forwarded.
+    # gen_ai.client.operation.duration arrives on [span_metrics]. Both forwarded.
     metrics:
-      receivers: [otlp, spanmetrics]
+      receivers: [otlp, span_metrics]
       exporters: [otlp_http/dynatrace]

--- a/test/e2e/fixture_assert_test.go
+++ b/test/e2e/fixture_assert_test.go
@@ -34,7 +34,7 @@ func assertSpanExistsWithin(t *testing.T, dql string, timeout time.Duration) {
 // metric reports data for the given service (5-minute timeout), failing the test
 // otherwise. This is the metric the AI Observability app charts
 // (timeseries avg(gen_ai.client.operation.duration)); the OTel Collector path
-// emits it via the spanmetrics connector in otel-collector-config.yaml, and the
+// emits it via the span_metrics connector in otel-collector-config.yaml, and the
 // OpenPipeline path via the samplingAwareHistogramMetric processor in
 // openpipeline-langfuse.yaml. Both carry service.name as a dimension.
 //

--- a/test/e2e/langfuse_opentelemetry_node_test.go
+++ b/test/e2e/langfuse_opentelemetry_node_test.go
@@ -13,7 +13,7 @@ func TestLangfuseOpenTelemetryNode(t *testing.T) {
 
 	// The AI Observability app charts both gen_ai.client.operation.duration and
 	// gen_ai.client.token.usage; the collector path derives duration via the
-	// built-in spanmetrics connector and token usage via signal_to_metrics, both
+	// built-in span_metrics connector and token usage via signal_to_metrics, both
 	// wired in ../opentelemetry/otel-collector-config.yaml (shared by this and the
 	// Python variant).
 	auditSpanWithMetrics(t, "langfuse", "opentelemetry-node", GenericProfile,

--- a/test/e2e/langfuse_opentelemetry_test.go
+++ b/test/e2e/langfuse_opentelemetry_test.go
@@ -12,7 +12,7 @@ func TestLangfuseOpenTelemetry(t *testing.T) {
 
 	// The AI Observability app charts both gen_ai.client.operation.duration and
 	// gen_ai.client.token.usage; the collector path derives duration via the
-	// built-in spanmetrics connector and token usage via signal_to_metrics, both
+	// built-in span_metrics connector and token usage via signal_to_metrics, both
 	// wired in otel-collector-config.yaml.
 	auditSpanWithMetrics(t, "langfuse", "opentelemetry", GenericProfile,
 		`fetch spans, from: now()-10m


### PR DESCRIPTION
Part 1 of 3 of the AI-352 rollout. Mechanical, no behaviour change.

`spanmetrics` is a deprecated alias for the `span_metrics` connector and logs a deprecation warning on every collector start. Renamed in the four demo configs that still use it, plus the genuine prose references in READMEs, a Makefile, `otel_setup.py`, and three e2e comments.

`aws-strands/**` is deliberately untouched — #TBD (the aws-strands duration-metrics PR) owns that file and does the same rename there.

## Verified

All four demos pin the same image, `ghcr.io/observiq/bindplane-agent:1.105.1` (tracks OTel contrib v0.157.0), so no config predates the rename. The premise was confirmed empirically rather than from memory: booting the pinned image on the old config emits `"spanmetrics" alias is deprecated; use "span_metrics" instead`, and the renamed config starts clean.

Each edited config was booted against the real image with dummy credentials and reached `Everything is ready. Begin running and processing data.` with no errors and no deprecation warning. Note the Bindplane wrapper has no working `validate` subcommand — it ignores the arg and boots the collector — so validation was by startup, not by `validate`.

## Follow-ups noticed, not fixed here

- Two Makefile comments still say the image tracks contrib v0.156.0, and `aws-bedrock/openinference/README.md:18` claims the pin is `1.104.0` while the Makefile pins `1.105.1`.
- The repo uses both `signal_to_metrics` and `signaltometrics` spellings across demos. Both are accepted by this image, so nothing is broken, but it looks like the same alias situation and may deserve its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)