### PR TITLE
AI-352: add the genai agent duration metrics to the comparison baseline

### DIFF
--- a/test/e2e/sdk-comparison-baseline.json
+++ b/test/e2e/sdk-comparison-baseline.json
@@ -1,10 +1,11 @@
 {
-  "version": "1.3.2",
+  "version": "1.4.0",
   "scope": "current-state",
-  "date": "2026-08-04",
+  "date": "2026-08-07",
   "source_app": "Dynatrace AI Observability",
   "purpose": "Single source of truth for comparing SDK/framework telemetry coverage",
   "changelog": [
+    "1.4.0 (2026-08-07): Add AR-054/AR-055/AR-056 for the GenAI agent, tool and workflow duration metrics (gen_ai.invoke_agent.duration, gen_ai.execute_tool.duration, gen_ai.invoke_workflow.duration). All three are Development-stability semconv metrics that no instrumentation library emits under these names, so demos derive them from spans via a collector span_metrics connector or an OpenPipeline metric extractor (AI-352). Recorded as optional with an empty used_by: no AI Observability view consumes them yet, so they are semconv coverage tracking rather than a dashboard dependency and are deliberately not added to any profile metrics list, where absence would fail the audit.",
     "1.3.2 (2026-08-04): Add gen_ai.usage.prompt_caching.read_tokens (AR-052) and gen_ai.usage.prompt_caching.write_tokens (AR-053) as optional attributes in a new caching-anthropic group; new anthropic profile (extends generic) in the e2e audit fixture. Live-verified against the ixq6468h sprint tenant on the anthropic/oneagent demo (AnthropicBedrock client + cache_control). Note: not yet visualised directly on any dashboard — these are the raw per-span inputs PPX's gen_ai.prompt.caching metric (AR-045) is computed from, not something a dashboard tile reads itself.",
     "1.3.1 (2026-07-28): Add gen_ai.guardrail.id (AR-050) and gen_ai.guardrail.version (AR-051) as provider-specific required attributes in the guardrails-bedrock group. Extracted from llm.invocation_parameters by the collector transform/llm-invocation-params processor (OpenInference path). Added to GuardrailProfile required checks in the e2e audit fixture.",
     "1.3.0 (2026-07-24): Add a per-profile metrics list. Move AR-025 (gen_ai.client.operation.duration) and AR-044 (gen_ai.client.token.usage) out of the generic optional_attributes into generic.metrics; they are verified as OTel metrics via timeseries existence, not as span attributes. The e2e suite now records metric-existence results in the generated per-SDK reports.",
@@ -215,6 +216,9 @@
       "gen_ai.guardrail.grounding_type": "AR-046",
       "gen_ai.usage.prompt_caching.read_tokens": "AR-052",
       "gen_ai.usage.prompt_caching.write_tokens": "AR-053",
+      "gen_ai.invoke_agent.duration": "AR-054",
+      "gen_ai.execute_tool.duration": "AR-055",
+      "gen_ai.invoke_workflow.duration": "AR-056",
       "span.status_code": "AR-047",
       "gen_ai.model": "AR-048",
       "event.type": "AR-049",
@@ -1101,6 +1105,42 @@
       "owned_by": "provider_sdk",
       "used_by": [],
       "note": "Per-span count of tokens written to the Anthropic/Bedrock prompt cache on a cache miss/first write. Not directly visualised by any dashboard today — see AR-052. Live-verified on the anthropic/oneagent demo against the ixq6468h sprint tenant on 2026-08-04."
+    },
+    {
+      "name": "gen_ai.invoke_agent.duration",
+      "rule_id": "AR-054",
+      "required_level": "optional",
+      "group": "agent-performance",
+      "type": "metric",
+      "providers": ["generic"],
+      "owned_by": "collector_processor",
+      "used_by": [],
+      "dimensions": ["gen_ai.agent.name", "gen_ai.operation.name"],
+      "note": "Duration of one GenAI agent invocation. Histogram, seconds, Development stability in the GenAI metrics semconv. No instrumentation library emits it under this name, so demos derive it from the invoke_agent span: a span_metrics connector on the collector path, a samplingAwareHistogramMetric extractor on the OpenPipeline path. used_by is empty on purpose — no AI Observability view consumes it yet, so it is coverage tracking, not a dashboard dependency, and must not gate a profile."
+    },
+    {
+      "name": "gen_ai.execute_tool.duration",
+      "rule_id": "AR-055",
+      "required_level": "optional",
+      "group": "agent-performance",
+      "type": "metric",
+      "providers": ["generic"],
+      "owned_by": "collector_processor",
+      "used_by": [],
+      "dimensions": ["gen_ai.tool.name", "gen_ai.operation.name"],
+      "note": "Duration of one GenAI tool execution. Histogram, seconds, Development stability in the GenAI metrics semconv. Derived from the execute_tool span the same two ways as AR-054. Not consumed by any AI Observability view yet."
+    },
+    {
+      "name": "gen_ai.invoke_workflow.duration",
+      "rule_id": "AR-056",
+      "required_level": "optional",
+      "group": "agent-performance",
+      "type": "metric",
+      "providers": ["generic"],
+      "owned_by": "collector_processor",
+      "used_by": [],
+      "dimensions": ["gen_ai.operation.name"],
+      "note": "Duration of one GenAI workflow run. Histogram, seconds, Development stability in the GenAI metrics semconv. Only derivable where the framework actually opens a workflow span: of the demos surveyed for AI-352 only microsoft-agent-framework does. aws-strands has no workflow primitive and the google-adk demo has no Workflow node, so neither emits it and neither should be audited for it. Not consumed by any AI Observability view yet."
     }
   ],
   "non_sdk_fields": [

--- a/test/e2e/sdk-comparison-baseline.md
+++ b/test/e2e/sdk-comparison-baseline.md
@@ -129,6 +129,9 @@ Profile precedence:
 | `gen_ai.token.type` | AR-024 | recommended | cost_dashboard — splits cost lanes; values: `input`, `output`, `cache_read`, `cache_creation` |
 | `gen_ai.client.operation.duration` | AR-025 | required | latency_charts — p99 and mean latency (OTel histogram metric) |
 | `gen_ai.client.token.usage` | AR-044 | recommended | cost_dashboard — OTel counter metric; used as `timeseries sum(gen_ai.client.token.usage)` filtered by `gen_ai.token.type` dimension. Distinct from the span attributes AR-006/AR-007. Missing → all cost tiles show $0 silently. |
+| `gen_ai.invoke_agent.duration` | AR-054 | optional | _(no view yet)_ — agent invocation duration; OTel histogram in seconds. Derived from the `invoke_agent` span by a collector `span_metrics` connector or an OpenPipeline extractor; no library emits it under this name. |
+| `gen_ai.execute_tool.duration` | AR-055 | optional | _(no view yet)_ — tool execution duration; derived from the `execute_tool` span the same two ways as AR-054. |
+| `gen_ai.invoke_workflow.duration` | AR-056 | optional | _(no view yet)_ — workflow run duration; only derivable where the framework opens a workflow span (of the AI-352 demos, only microsoft-agent-framework does). |
 
 ### Operations & Agents
 
@@ -387,3 +390,4 @@ These rules model app behavior better than a flat required/optional list.
 - Always check `changelog` in `sdk-comparison-baseline.json` to confirm you are reading the current version before running a comparison.
 - For AR-020 and AR-021: their absence from a Bedrock SDK does NOT degrade any current dashboard. Report them as `dashboard_gaps` (SDK should emit them; dashboard does not yet visualise them) rather than `silent_failures`.
 - `gen_ai.client.token.usage` (AR-044) is a metric, not a span attribute. Its presence cannot be inferred from span traces alone — it requires a metrics pipeline (e.g. `should_enrich_metrics=True` in Traceloop, or a custom `MeterProvider`).
+- The agent duration metrics (AR-054, AR-055, AR-056) are metrics too, and are **optional with an empty `used_by`** on purpose. No AI Observability view consumes them yet — they are tracked here as semconv coverage, not as a dashboard dependency. Do **not** add them to a profile's `metrics` list: every key in a profile metric list is mandatory and absence fails the audit, so gating on them would fail every demo that does not derive them. AR-056 in particular is only derivable where the framework actually opens a workflow span.


### PR DESCRIPTION
Documentation-only. The demos started deriving the GenAI agent duration metrics in AI-352 (#228 merged, #231 and #232 open), but `test/e2e/sdk-comparison-baseline.{json,md}` — the ground truth for what the e2e suite asserts — never learned about them.

Adds `AR-054` / `AR-055` / `AR-056` for `gen_ai.invoke_agent.duration`, `gen_ai.execute_tool.duration` and `gen_ai.invoke_workflow.duration`, in both the JSON entries and the `attribute_rule_ids` map, plus the matching rows in the Markdown table. Baseline bumped to 1.4.0 with a changelog entry.

## The one judgement call

All three are recorded as **`optional` with an empty `used_by`**, and are deliberately **not** added to any profile's `metrics` list.

No AI Observability view consumes them yet — that is the whole premise of AI-352, the app charts 2 of the 12 semconv metrics. So they are semconv *coverage tracking*, not a dashboard dependency. Putting them in `profiles.generic.metrics` alongside AR-025/AR-044 would make them mandatory: every key in a profile metric list fails the audit when absent, so it would fail every demo that does not derive them, which today is most of them. `AR-056` is worse still — it is only derivable where the framework actually opens a workflow span, which of the surveyed demos is microsoft-agent-framework alone.

If we later want these tracked as a pass/fail gate rather than as coverage, that needs the `optionalMetricKeys` path already noted as a follow-up on the ticket — with a shorter timeout, since each absent optional key would otherwise burn the full 5-minute `pollMetricExists` budget.

## Note on numbering

Originally opened as AR-052/053/054; #213 landed on main first and claimed AR-052 and AR-053 for the prompt-caching token attributes, so these were renumbered to **AR-054/AR-055/AR-056** and the branch rebased. The baseline changelog is newest-first, and the new entry is inserted at the top accordingly.

## Verified

JSON parses; no duplicate rule ids anywhere in the file; rule-id map, attribute entries and Markdown rows agree on all three ids; `profile_selection` is byte-unchanged. No Go code touched, so no test behaviour changes with this PR alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
