### PR TITLE
derive genai client metrics in langgraph/openinference collector

### DIFF
--- a/langgraph/openinference/README.md
+++ b/langgraph/openinference/README.md
@@ -44,6 +44,7 @@ Uses [`openinference-instrumentation-langchain`](https://github.com/Arize-ai/ope
 1. In Dynatrace press `Ctrl+K` and search for **Access tokens**.
 2. Create a token with these permissions:
    - `openTelemetryTrace.ingest`
+   - `metrics.ingest` (for the derived GenAI client metrics)
 3. Copy the token value.
 
 ### 2. Set environment variables
@@ -113,6 +114,17 @@ Two additional processors run after normalization:
 
 - **`transform/response_model`** — mirrors `gen_ai.request.model` → `gen_ai.response.model` when absent (OpenInference has no separate response-model field).
 - **`transform/output_prompt_results`** — extracts Azure OpenAI content-filter verdicts from the `output.value` JSON blob emitted by LangChain's Azure OpenAI integration and sets them as `gen_ai.prompt.prompt_filter_results`. This makes per-prompt filter results (hate, self-harm, sexual, violence, jailbreak) visible in Dynatrace AI Observability's content-filter view.
+
+### Derived metrics
+
+OpenInference is span-only: it emits no metric instruments, so the two GenAI client metrics the AI Observability app charts are derived from the normalized spans by collector connectors.
+
+| Metric | Derived by |
+|---|---|
+| `gen_ai.client.operation.duration` (s) | `span_metrics` connector, on LLM spans |
+| `gen_ai.client.token.usage` (`gen_ai.token.type` = `input`/`output`) | `signal_to_metrics` connector, two sum defs (one per direction) |
+
+Both run on a separate `traces/genai_metrics` pipeline branch, so the `filter/genai_only` filter that restricts them to LLM spans can never drop a span from the trace export path. Both use delta temporality, which Dynatrace metric ingest requires (cumulative is dropped). The Dynatrace API token needs the `metrics.ingest` scope in addition to `openTelemetryTrace.ingest`.
 
 ---
 

--- a/langgraph/openinference/otel-collector-config.yaml
+++ b/langgraph/openinference/otel-collector-config.yaml
@@ -57,7 +57,75 @@ processors:
           - set(attributes["gen_ai.completion.content_filter_results"], String(attributes["temp.output_value"]["generations"][0][0]["generation_info"]["content_filter_results"])) where attributes["temp.output_value"]["generations"][0][0]["generation_info"]["content_filter_results"] != nil
           - delete_key(attributes, "temp.output_value")
 
+  # Keep only spans that represent an LLM call (gen_ai.request.model is set by the
+  # normalizer on LLM spans). Feeds the metrics connectors so the derived metrics
+  # cover LLM calls only, not chain/tool/agent spans. Used solely on the metrics
+  # branch; the export pipeline is left untouched so all spans still reach
+  # Distributed Tracing.
+  filter/genai_only:
+    error_mode: ignore
+    traces:
+      span:
+        - attributes["gen_ai.request.model"] == nil
 
+connectors:
+  # Duration: derive gen_ai.client.operation.duration (OTel GenAI semconv, seconds)
+  # from the LLM span durations. namespace + the connector's "duration" histogram
+  # => gen_ai.client.operation.duration.
+  span_metrics:
+    namespace: gen_ai.client.operation
+    # Dynatrace OTLP metric ingest accepts delta temporality only; cumulative is dropped.
+    aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA
+    histogram:
+      unit: s
+      explicit:
+        buckets: [100ms, 250ms, 500ms, 1s, 2s, 5s, 10s, 30s, 60s]
+    dimensions:
+      - name: gen_ai.request.model
+      - name: gen_ai.response.model
+      - name: gen_ai.provider.name
+      - name: gen_ai.operation.name
+    metrics_flush_interval: 15s
+
+  # Token usage: OpenInference is span-only (no metric instruments), so the token
+  # counts live only as span attributes. Re-create gen_ai.client.token.usage from
+  # them with two sum defs sharing one metric name; the gen_ai.token.type dimension
+  # is synthesized per direction via default_value (the span carries no such
+  # attribute). signal_to_metrics emits delta per batch, which Dynatrace requires.
+  signal_to_metrics:
+    spans:
+      - name: gen_ai.client.token.usage
+        description: "Number of tokens used per LLM call, by direction"
+        unit: "{token}"
+        conditions:
+          - attributes["gen_ai.usage.input_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.input_tokens"])
+          monotonic: true
+        attributes:
+          - key: gen_ai.token.type
+            default_value: input
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+      - name: gen_ai.client.token.usage
+        description: "Number of tokens used per LLM call, by direction"
+        unit: "{token}"
+        conditions:
+          - attributes["gen_ai.usage.output_tokens"] != nil
+        sum:
+          value: Int(attributes["gen_ai.usage.output_tokens"])
+          monotonic: true
+        attributes:
+          - key: gen_ai.token.type
+            default_value: output
+          - key: gen_ai.request.model
+          - key: gen_ai.response.model
+          - key: gen_ai.provider.name
+          - key: gen_ai.operation.name
+      # service.name is a resource attribute included by default — no
+      # include_resource_attributes filter needed, same as span_metrics.
 
 exporters:
   debug:
@@ -73,3 +141,13 @@ service:
       receivers: [otlp]
       processors: [transform/output_prompt_results, gen_ai_normalizer, transform/response_model]
       exporters: [debug, otlp_http/dynatrace]
+    # Second branch of the same spans: normalize, keep only LLM spans, and feed
+    # the metric connectors. Kept separate from the export pipeline so the filter
+    # here never drops spans from Distributed Tracing.
+    traces/genai_metrics:
+      receivers: [otlp]
+      processors: [gen_ai_normalizer, transform/response_model, filter/genai_only]
+      exporters: [span_metrics, signal_to_metrics]
+    metrics:
+      receivers: [span_metrics, signal_to_metrics]
+      exporters: [otlp_http/dynatrace]

--- a/test/e2e/langgraph_openinference_test.go
+++ b/test/e2e/langgraph_openinference_test.go
@@ -8,11 +8,12 @@ func TestLangGraphOpenInference(t *testing.T) {
 	startApp(t, "langgraph/openinference")
 	makeRequest(t, "langgraph/openinference", "request")
 
-	auditSpan(t, "langgraph", "openinference", AzureProfile,
+	auditSpanWithMetrics(t, "langgraph", "openinference", AzureProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "langgraph/openinference"
 | filter isNotNull(gen_ai.request.model)
 | sort timestamp desc
 | filter isNull(span.status_code) or span.status_code != "error"
-| limit 1`)
+| limit 1`,
+		"langgraph/openinference", genAIClientMetrics)
 }


### PR DESCRIPTION
## What was missing

`langgraph/openinference` emitted spans only. Neither `gen_ai.client.token.usage` nor `gen_ai.client.operation.duration` reached Dynatrace, so the demo showed up in Distributed Tracing but contributed nothing to the AI Observability app's cost and latency charts. Its two sibling OpenInference demos (`openai/openinference`, `aws-bedrock/openinference`) already derive both.

## What changed

Config only. Three files:

**`langgraph/openinference/otel-collector-config.yaml`**
- `filter/genai_only` processor: drops spans with no `gen_ai.request.model`, so the metrics cover LLM calls only and not chain/tool/agent spans.
- `span_metrics` connector, namespace `gen_ai.client.operation`, with `aggregation_temporality: AGGREGATION_TEMPORALITY_DELTA` => `gen_ai.client.operation.duration` (seconds).
- `signal_to_metrics` connector, two sum defs sharing the name `gen_ai.client.token.usage`, with `gen_ai.token.type` synthesized per direction via `default_value` (the span carries no such attribute). Delta per batch already.
- New `traces/genai_metrics` pipeline branch plus a `metrics` pipeline. The branch is separate from the trace export pipeline, so `filter/genai_only` can never drop a span from Distributed Tracing.

**`test/e2e/langgraph_openinference_test.go`** — `auditSpan` becomes `auditSpanWithMetrics(..., "langgraph/openinference", genAIClientMetrics)`, matching the siblings. This demo has a single run path (no `run-collector` variant), so no `service.name` split was needed.

**`langgraph/openinference/README.md`** — documents the two derived metrics and adds `metrics.ingest` to the required token scopes.

The mechanism is copied from the two sibling OpenInference demos; the comment style follows theirs.

## Why no app change was needed

Pipeline-over-app-code is the project rule, and the prerequisites were already in place:

- `gen_ai_normalizer` with source `openinference` and `remove_originals: true` already maps `llm.token_count.prompt` / `.completion` to `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens`, and `transform/response_model` already mirrors request model to response model. Both connectors read only those normalized attributes.
- The Makefile already pinned `ghcr.io/observiq/bindplane-agent:1.105.1`. This matters: `signal_to_metrics` ships in the Bindplane distro, not the Dynatrace collector distro. No image change.

The existing `transform/output_prompt_results` (Azure content-filter extraction from the `output.value` JSON blob) only sets attributes and deletes a temp key; it never drops or reshapes the LLM span, so it does not starve the metrics branch. It stays on the trace export branch only, since the filter results are a span concern, not a metric one.

## Verification

Config load and a real data smoke test against the pinned Bindplane image. `validate` is not a recognized subcommand in that image (the entrypoint ignores it and starts the collector), so instead the config was loaded for real and fed a synthetic OpenInference LangChain span.

Startup was clean: `span_metrics`, `signal_to_metrics`, `filter/genai_only` and both trace pipelines all built, `Everything is ready. Begin running and processing data.`, no config errors.

With one synthetic span (1.5s, 57 prompt / 23 completion tokens), the debug exporter showed all three metrics:

```
gen_ai.client.token.usage        Sum,  Delta, monotonic
  gen_ai.token.type=input   value 57
  gen_ai.token.type=output  value 23
  dims: gen_ai.request.model, gen_ai.response.model, gen_ai.provider.name, gen_ai.operation.name

gen_ai.client.operation.duration Histogram, Delta, unit s
  count 1, sum 1.5, lands in the 1s-2s bucket

gen_ai.client.operation.calls    Sum, Delta, monotonic, value 1
```

`gen_ai.client.operation.calls` is the counter `span_metrics` always emits and cannot be disabled. Neither sibling config suppresses it, so this one does not either.

The span itself confirmed the normalizer leaves `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` and `gen_ai.response.model` in place, which is exactly what the connectors key on.

`cd test/e2e && go vet ./...` and `go build ./...` both clean.

## Not verified

The live e2e has **not** been run locally (it needs tenant credentials). CI is the first real end-to-end confirmation that the metrics land in Dynatrace and that `pollMetricExists` finds them for `service.name == "langgraph/openinference"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
