### PR TITLE
fix google-adk collector e2e: service name, BDOT --config, timeout

### DIFF
--- a/.github/scripts/compute-e2e-matrix.sh
+++ b/.github/scripts/compute-e2e-matrix.sh
@@ -51,7 +51,7 @@ OC_ALL='[
   {"name":"langgraph-openinference","app_dir":"langgraph/openinference","test_file":"test/e2e/langgraph_openinference_test.go","test_run":"TestLangGraphOpenInference","otel_service_name":"langgraph/openinference"},
   {"name":"aws-strands-opentelemetry","app_dir":"aws-strands/opentelemetry","test_file":"test/e2e/aws_strands_opentelemetry_test.go","test_run":"TestAWSStrandsOpenTelemetry","otel_service_name":"aws-strands/opentelemetry"},
   {"name":"aws-strands-opentelemetry-openpipeline","app_dir":"aws-strands/opentelemetry","test_file":"test/e2e/aws_strands_opentelemetry_openpipeline_test.go","test_run":"TestAWSStrandsOpenTelemetryOpenPipeline","otel_service_name":"aws-strands/opentelemetry-openpipeline"},
-  {"name":"google-adk-opentelemetry","app_dir":"google-adk/opentelemetry","test_file":"test/e2e/google_adk_opentelemetry_collector_test.go","test_run":"TestGoogleADKOpenTelemetryCollector","otel_service_name":"google-adk-samples","model":"gemini-3.1-flash-lite","needs_google":true},
+  {"name":"google-adk-opentelemetry","app_dir":"google-adk/opentelemetry","test_file":"test/e2e/google_adk_opentelemetry_collector_test.go","test_run":"TestGoogleADKOpenTelemetryCollector","otel_service_name":"google-adk-collector","model":"gemini-3.1-flash-lite","needs_google":true},
   {"name":"rum-opentelemetry","app_dir":"rum/opentelemetry","test_file":"test/e2e/rum_sessionid_agentic_test.go","test_run":"TestRUMOpenTelemetry","otel_service_name":"rum/opentelemetry","needs_playwright":true},
   {"name":"dt-evals-fixtures-opentelemetry","app_dir":"dt-evals-fixtures/opentelemetry","test_file":"test/e2e/dt_evals_fixtures_opentelemetry_test.go","test_run":"TestDtEvalsFixturesOpenTelemetry","otel_service_name":"dt-evals-fixtures"}
 ]'

--- a/google-adk/opentelemetry/Makefile
+++ b/google-adk/opentelemetry/Makefile
@@ -51,7 +51,7 @@ _collector:
 	  -v $$(pwd)/$(CONFIG):/etc/otel/config.yaml:ro \
 	  -e DT_ENDPOINT=$(DT_ENDPOINT) \
 	  -e DT_API_TOKEN=$(DT_API_TOKEN) \
-	  $(COLLECTOR_IMAGE) && \
+	  $(COLLECTOR_IMAGE) --config=/etc/otel/config.yaml && \
 	docker logs -f $(COLLECTOR_CONTAINER) > collector.log 2>&1 & \
 	echo "Collector logs -> collector.log" && \
 	for i in $$(seq 1 15); do \

--- a/test/e2e/internal/process/app.go
+++ b/test/e2e/internal/process/app.go
@@ -39,6 +39,8 @@ func Start(dir string) (*App, error) {
 // StartWithTarget runs "make -e <target>" in dir as a background process and
 // waits for port 8000 to accept connections before returning. Use for HTTP apps
 // that need a non-default make target (e.g. "run-collector").
+// Uses a longer timeout than Start because collector targets pull a Docker image
+// on the first run (60-90s) before the app itself can start.
 func StartWithTarget(dir, target string) (*App, error) {
 	cmd := exec.Command("make", "-e", target)
 	cmd.Dir = dir
@@ -50,7 +52,7 @@ func StartWithTarget(dir, target string) (*App, error) {
 		return nil, fmt.Errorf("make %s: %w", target, err)
 	}
 	a := &App{cmd: cmd}
-	if err := a.waitReady(90 * time.Second); err != nil {
+	if err := a.waitReady(3 * time.Minute); err != nil {
 		_ = a.Stop()
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Fix `otel_service_name` in the matrix from `google-adk-samples` to `google-adk-collector` — the collector config renames the service, so the DQL span filter and metric isolation were matching the wrong service
- Pass `--config=/etc/otel/config.yaml` explicitly to the BDOT container so it reads local config on startup instead of waiting for a BindPlane management server connection (which caused the 30-iteration readiness loop to exhaust)
- Raise `StartWithTarget` `waitReady` from 90s to 3 minutes — collector targets pull a Docker image on a fresh CI runner (60-90s) before the app can start, leaving the old timeout no headroom

Fixes #246 

## Test plan

- [ ] `TestGoogleADKOpenTelemetryCollector` passes in CI without timing out