### PR TITLE
AI-80: Fix SDK delta: Microsoft-Agent-Framework

### DIFF
--- a/microsoft-agent-framework/opentelemetry/otel-collector-config.yaml
+++ b/microsoft-agent-framework/opentelemetry/otel-collector-config.yaml
@@ -66,6 +66,19 @@ processors:
   #
   # Note log.source is a permission-relevant field in Dynatrace, so changing this
   # value later can change which bucket/permissions the records fall under.
+  
+  # MAF does not set OTel span status on success, leaving it UNSET.
+  # Set OK for gen_ai operation spans and workflow spans so the service health
+  # tile in Dynatrace reflects success. ERROR is set automatically by the SDK
+  # when an exception propagates through a span.
+  transform/span_status:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(status.code, STATUS_CODE_OK) where attributes["gen_ai.operation.name"] != nil and status.code == STATUS_CODE_UNSET
+          - set(status.code, STATUS_CODE_OK) where name == "workflow.run" and status.code == STATUS_CODE_UNSET
+
   transform/log_source:
     error_mode: ignore
     log_statements:
@@ -132,7 +145,7 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [transform/span_status, batch]
       exporters: [otlphttp/dynatrace]
 
     # One metrics branch per span type. Kept separate from the export pipeline


### PR DESCRIPTION
**Adds span status to microsoft-agent-framework OTel collector config:**

Closes optional improvement **AR-047 `(span.status_code)`**. Adds a transform/span_status processor to the collector config that sets STATUS_CODE_OK on gen_ai.* operation spans and workflow.run spans when status is UNSET. 

ERROR status is preserved by the `where status.code == STATUS_CODE_UNSET` guard — the framework sets STATUS_CODE_ERROR automatically when an exception propagates through a span.