### PR TITLE
AI-73: Fix SDK delta: aws-bedrock 

### DIFF
--- a/aws-bedrock/opentelemetry/README.md
+++ b/aws-bedrock/opentelemetry/README.md
@@ -41,19 +41,11 @@ The Traceloop decorators tag their spans with `traceloop.span.kind` but never se
 
 ## Guardrails
 
-`run_converse_guardrail_trigger()` sends prompts that violate a configured [Bedrock Guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) across three policy types so you can see blocked requests in Dynatrace. When `BEDROCK_GUARDRAIL_ID` is set, every Converse call attaches the guardrail with `trace: enabled`, and the instrumentation (`opentelemetry.instrumentation.bedrock`) maps the assessment onto the span:
+`run_converse_guardrail_trigger()` sends prompts that violate a configured [Bedrock Guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) so you can see blocked requests in Dynatrace. When `BEDROCK_GUARDRAIL_ID` is set, every Converse call attaches the guardrail with `trace: enabled`, and the instrumentation (`opentelemetry.instrumentation.bedrock`) maps the assessment onto the span:
 
 - `gen_ai.response.finish_reasons = ["content_filter"]` and an `Input blocked` output message
 - `gen_ai.bedrock.guardrail.activation`, `.input_filter`, `.topics`, `.content`, `.sensitive_info`
 - `gen_ai.guardrail.id` / `.version`
-
-The `guardrails` story sends prompts to exercise different policy types:
-
-| Prompt | Policy | Span attribute |
-|---|---|---|
-| Football strategies | Topic (denied topics) | `gen_ai.bedrock.guardrail.topics` |
-| Insult prompt | Content (hate/insults) | `gen_ai.bedrock.guardrail.content` |
-| SSN prompt | Sensitive information (PII) | `gen_ai.bedrock.guardrail.sensitive_info` |
 
 Set `BEDROCK_GUARDRAIL_ID` (and optionally `BEDROCK_GUARDRAIL_VERSION`, default `DRAFT`) to enable it; without it the guardrail story is skipped.
 

--- a/aws-bedrock/opentelemetry/README.md
+++ b/aws-bedrock/opentelemetry/README.md
@@ -41,11 +41,19 @@ The Traceloop decorators tag their spans with `traceloop.span.kind` but never se
 
 ## Guardrails
 
-`run_converse_guardrail_trigger()` sends a prompt that violates a configured [Bedrock Guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) (a denied-topics policy) so you can see a blocked request in Dynatrace. When `BEDROCK_GUARDRAIL_ID` is set, every Converse call attaches the guardrail with `trace: enabled`, and the instrumentation (`opentelemetry.instrumentation.bedrock`) maps the assessment onto the span:
+`run_converse_guardrail_trigger()` sends prompts that violate a configured [Bedrock Guardrail](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails.html) across three policy types so you can see blocked requests in Dynatrace. When `BEDROCK_GUARDRAIL_ID` is set, every Converse call attaches the guardrail with `trace: enabled`, and the instrumentation (`opentelemetry.instrumentation.bedrock`) maps the assessment onto the span:
 
 - `gen_ai.response.finish_reasons = ["content_filter"]` and an `Input blocked` output message
-- `gen_ai.bedrock.guardrail.activation`, `.input_filter`, `.topics`
+- `gen_ai.bedrock.guardrail.activation`, `.input_filter`, `.topics`, `.content`, `.sensitive_info`
 - `gen_ai.guardrail.id` / `.version`
+
+The `guardrails` story sends prompts to exercise different policy types:
+
+| Prompt | Policy | Span attribute |
+|---|---|---|
+| Football strategies | Topic (denied topics) | `gen_ai.bedrock.guardrail.topics` |
+| Insult prompt | Content (hate/insults) | `gen_ai.bedrock.guardrail.content` |
+| SSN prompt | Sensitive information (PII) | `gen_ai.bedrock.guardrail.sensitive_info` |
 
 Set `BEDROCK_GUARDRAIL_ID` (and optionally `BEDROCK_GUARDRAIL_VERSION`, default `DRAFT`) to enable it; without it the guardrail story is skipped.
 

--- a/aws-bedrock/opentelemetry/main.py
+++ b/aws-bedrock/opentelemetry/main.py
@@ -10,6 +10,7 @@ from tenacity import sleep
 from traceloop.sdk import Traceloop
 import logging
 import json
+import uuid
 
 from opentelemetry.instrumentation.bedrock import BedrockInstrumentor
 from opentelemetry.instrumentation.requests import RequestsInstrumentor
@@ -21,6 +22,7 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry._logs import set_logger_provider
 
 from traceloop.sdk.decorators import workflow, task, agent
+from traceloop.sdk.tracing.tracing import set_conversation_id
 from opentelemetry import trace as _ot_trace
 
 COLLECTOR_BASE_URL = "http://localhost:4318"
@@ -85,6 +87,8 @@ def run_converse(client_context):
     logging.info("Calling Converse API with Boto3...")
     kwargs = {
         "modelId": MODEL_ID,
+        "system": [{"text": "You are a helpful assistant that tells short bedtime stories."}],
+        "inferenceConfig": {"temperature": 0.7},
         "messages": [
             {
                 "role": "user",
@@ -100,19 +104,14 @@ def run_converse(client_context):
 
 
 @task("run_converse_guardrail_trigger")
-def run_converse_guardrail_trigger(client_context):
+def run_converse_guardrail_trigger(client_context, text):
     gc = _guardrail_config()
     if not gc:
         return
     logging.info("Calling Converse API with a prompt designed to trigger the guardrail...")
     response = client_context.converse(
         modelId=MODEL_ID,
-        messages=[
-            {
-                "role": "user",
-                "content": [{"text": "What are the best football strategies for the World Cup?"}]
-            }
-        ],
+        messages=[{"role": "user", "content": [{"text": text}]}],
         guardrailConfig=gc,
     )
     stop_reason = response.get("stopReason", "")
@@ -233,7 +232,11 @@ def _run_story(name, client):
     elif name == "guardrails":
         if not _guardrail_config():
             logging.warning("story 'guardrails' selected but BEDROCK_GUARDRAIL_ID is unset; nothing to trigger")
-        run_converse_guardrail_trigger(client)
+        # Synthetic test inputs to trigger topic, content and sensitive info guardrail policies
+        # These prompts are intentionally blocked by the guardrail and should never reach the model
+        run_converse_guardrail_trigger(client, "What are the best football strategies for the World Cup?")
+        run_converse_guardrail_trigger(client, "Generate a mean insult.")
+        run_converse_guardrail_trigger(client, "My SSN is 123-45-6789.")
     elif name == "invoke":
         run_invoke(client)
         run_invoke_extra(client)
@@ -260,6 +263,7 @@ def _selected_stories():
 @workflow("aws_bedrock_agent")
 def run_workflow():
     logging.info("Starting the Workflow...")
+    set_conversation_id(str(uuid.uuid4()))
     client = boto3.client("bedrock-runtime", region_name="us-east-1")
 
     for story in _selected_stories():

--- a/aws-bedrock/opentelemetry/main.py
+++ b/aws-bedrock/opentelemetry/main.py
@@ -236,7 +236,7 @@ def _run_story(name, client):
         # These prompts are intentionally blocked by the guardrail and should never reach the model
         run_converse_guardrail_trigger(client, "What are the best football strategies for the World Cup?")
         run_converse_guardrail_trigger(client, "Generate a mean insult.")
-        run_converse_guardrail_trigger(client, "My SSN is 123-45-6789.")
+        run_converse_guardrail_trigger(client, "Please help me update my personal records. My SSN is 427-83-1562.")
     elif name == "invoke":
         run_invoke(client)
         run_invoke_extra(client)

--- a/aws-bedrock/opentelemetry/otel-collector-config.yaml
+++ b/aws-bedrock/opentelemetry/otel-collector-config.yaml
@@ -65,6 +65,13 @@ processors:
           # so only the agent name needs mirroring — and this demo has no @tool.)
           - set(span.attributes["gen_ai.agent.name"], span.attributes["traceloop.entity.name"]) where span.attributes["traceloop.span.kind"] == "agent" and span.attributes["gen_ai.agent.name"] == nil
 
+  transform/span_status:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - set(status.code, STATUS_CODE_OK) where attributes["gen_ai.operation.name"] != nil and status.code == STATUS_CODE_UNSET
+
   # One filter per metric branch, each dropping every span that is not the one
   # its metric is defined over. The export pipeline below is untouched, so all
   # spans still reach Distributed Tracing regardless of what these drop.
@@ -152,6 +159,7 @@ service:
         [
           transform/bedrock-guardrail-attrs,
           transform/traceloop_operation_name,
+          transform/span_status,
           batch,
         ]
       exporters: [otlphttp/dynatrace]


### PR DESCRIPTION
## Summary

- Refactors `run_converse_guardrail_trigger` to accept a `text` parameter, so the same `@task` can cover multiple guardrail policy types and add two additional guardrail trigger calls in the `guardrails` story to exercise the content policy (insult prompt) and sensitive info policy (SSN prompt) in addition to the existing topic policy (football prompt); all three are synthetic test inputs intentionally blocked before reaching the model
- Adds system instructions and `inferenceConfig.temperature` to `run_converse` so `gen_ai.system_instructions` (AR-043) and `gen_ai.request.temperature` (AR-042) are captured by `BedrockInstrumentor` and appear on the span
- Sets a per-run `gen_ai.conversation.id` via `set_conversation_id` at the start of `run_workflow` so the attribute (AR-041) is propagated across all spans in the workflow
- Adds a transform/span_status to the OTel collector config to set `span.status_code = OK` on successful `gen_ai` spans (AR-047)