### PR TITLE
AI-72: Fix SDK delta: aws-bedrock-agents-oneagent

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -357,6 +357,33 @@ jobs:
           AZURE_OPENAI_API_VERSION: ${{ secrets.AZURE_OPENAI_API_VERSION }}
         run: go test ./... -run "^${TEST_RUN}$" -v -timeout 20m
 
+      - name: Run aws-bedrock-agents-oneagent
+        if: always()
+        working-directory: test/e2e
+        env:
+          TEST_RUN: TestAWSBedrockAgentsOneAgent
+          OTEL_SERVICE_NAME: aws-bedrock-agents/oneagent
+          BEDROCK_GUARDRAIL_ID: ${{ secrets.BEDROCK_GUARDRAIL_ID }}
+          BEDROCK_GUARDRAIL_VERSION: ${{ secrets.BEDROCK_GUARDRAIL_VERSION }}
+        run: go test ./... -run "^${TEST_RUN}$" -v -timeout 20m
+
+      - name: Run mistral-oneagent
+        if: always()
+        working-directory: test/e2e
+        env:
+          TEST_RUN: TestMistralOneAgent
+          OTEL_SERVICE_NAME: mistral/oneagent
+          MODEL: mistral-small-latest
+        run: go test ./... -run "^${TEST_RUN}$" -v -timeout 20m
+
+      - name: Run langgraph-oneagent
+        if: always()
+        working-directory: test/e2e
+        env:
+          TEST_RUN: TestLangGraphOneAgent
+          OTEL_SERVICE_NAME: langgraph/oneagent
+        run: go test ./... -run "^${TEST_RUN}$" -v -timeout 20m
+
       # aws-strands-oneagent runs last: it appears to need more OneAgent sensor warm-up time than
       # other suites (likely due to threading instrumentation via ThreadingInstrumentor). Running
       # last means an estimated ~15min of prior suite wall-clock time has elapsed since OneAgent

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,6 +94,7 @@ jobs:
             https://*) ;;
             *) echo "Error: DT_ENDPOINT must start with https://"; exit 1 ;;
           esac
+          echo "Reaching out to: ${DT_ENDPOINT:4}"
           VERSION=$(curl -sS --fail \
             --header "Authorization: Api-Token ${DT_INSTALLER_TOKEN}" \
             "${DT_ENDPOINT}/api/v1/deployment/installer/agent/unix/default/latest/metainfo?arch=x86" \

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -94,7 +94,6 @@ jobs:
             https://*) ;;
             *) echo "Error: DT_ENDPOINT must start with https://"; exit 1 ;;
           esac
-          echo "Reaching out to: ${DT_ENDPOINT:4}"
           VERSION=$(curl -sS --fail \
             --header "Authorization: Api-Token ${DT_INSTALLER_TOKEN}" \
             "${DT_ENDPOINT}/api/v1/deployment/installer/agent/unix/default/latest/metainfo?arch=x86" \

--- a/aws-bedrock-agents/oneagent/main.py
+++ b/aws-bedrock-agents/oneagent/main.py
@@ -91,15 +91,9 @@ async def invoke(payload):
 
     if _guardrail_config():
         print("=================")
-        for prompt in [
-            # Synthetic test inputs to trigger topic, content and sensitive info guardrail policies
-            # These prompts are intentionally blocked by the guardrail and should never reach the model
-            "What are the best football strategies for the World Cup?",
-            "Generate a mean insult.",
-            "Please help me update my personal records. My SSN is 427-83-1562.",
-        ]:
-            guardrail_result = await asyncio.to_thread(run_agent, prompt)
-            print(f"Guardrail trigger result ({prompt[:40]}...):\n", guardrail_result)
+        guardrail_result = await asyncio.to_thread(run_agent, "Generate a mean insult. What are the best football strategies for the World Cup. My SSN is 427-83-1562.")
+        print("Guardrail trigger result:\n", guardrail_result)
+        
 
 if __name__ == "__main__":
     agentcore.run(port=int(os.getenv("PORT", "8000")))

--- a/aws-bedrock-agents/oneagent/main.py
+++ b/aws-bedrock-agents/oneagent/main.py
@@ -91,9 +91,15 @@ async def invoke(payload):
 
     if _guardrail_config():
         print("=================")
-        guardrail_result = await asyncio.to_thread(run_agent, "What are the best football strategies for the World Cup?")
-        print("Guardrail trigger result:\n", guardrail_result)
-
+        for prompt in [
+            # Synthetic test inputs to trigger topic, content and sensitive info guardrail policies
+            # These prompts are intentionally blocked by the guardrail and should never reach the model
+            "What are the best football strategies for the World Cup?",
+            "Generate a mean insult.",
+            "Please help me update my personal records. My SSN is 427-83-1562.",
+        ]:
+            guardrail_result = await asyncio.to_thread(run_agent, prompt)
+            print(f"Guardrail trigger result ({prompt[:40]}...):\n", guardrail_result)
 
 if __name__ == "__main__":
     agentcore.run(port=int(os.getenv("PORT", "8000")))

--- a/test/e2e/aws_bedrock_agents_oneagent_test.go
+++ b/test/e2e/aws_bedrock_agents_oneagent_test.go
@@ -27,7 +27,7 @@ func TestAWSBedrockAgentsOneAgent(t *testing.T) {
 
 	// The guardrail-triggering request is always sent last, so the latest
 	// matching span is the one that actually tripped the guardrail.
-	auditGuardrailSpan(t, "aws-bedrock-agents", "oneagent",
+	auditOneAgentGuardrailSpan(t, "aws-bedrock-agents", "oneagent",
 		`fetch spans, from: now()-10m
 | filter service.name == "aws-bedrock-agents/oneagent"
 | filter (gen_ai.provider.name == "aws_bedrock") and dt.openpipeline.source == "oneagent"

--- a/test/e2e/fixture_audit_test.go
+++ b/test/e2e/fixture_audit_test.go
@@ -142,6 +142,21 @@ var GuardrailProfile = Profile{
 	},
 }
 
+var OneAgentGuardrailProfile = Profile{
+	Name: "oneagent-bedrock-guardrail",
+	Required: []AttributeCheck{
+		{Name: "gen_ai.guardrail.input.sensitive_information.piis", RuleID: "AR-057"},
+		{Name: "gen_ai.guardrail.input.content", RuleID: "AR-058"},
+		{Name: "gen_ai.guardrail.input.topic.names", RuleID: "AR-059"},
+		{Name: "gen_ai.guardrail.id", RuleID: "AR-050"},
+		{Name: "gen_ai.guardrail.version", RuleID: "AR-051"},
+	},
+	Optional: []AttributeCheck{
+		{Name: "gen_ai.guardrail.output.contextual", RuleID: "AR-060"},
+		{Name: "gen_ai.guardrail.input.words.matches", RuleID: "AR-061"},
+	},
+}
+
 // OpenAIProfile extends generic with OpenAI prompt-caching attributes.
 var OpenAIProfile Profile
 
@@ -564,6 +579,11 @@ func auditSpanOptional(t *testing.T, sdk, instrumentation string, p Profile, dql
 func auditGuardrailSpan(t *testing.T, sdk, instrumentation, dql string, note ...string) {
 	t.Helper()
 	auditSpanOptional(t, sdk, instrumentation+"-guardrail", GuardrailProfile, dql, note...)
+}
+
+func auditOneAgentGuardrailSpan(t *testing.T, sdk, instrumentation, dql string, note ...string) {
+	t.Helper()
+	auditSpanOptional(t, sdk, instrumentation+"-guardrail", OneAgentGuardrailProfile, dql, note...)
 }
 
 // fetchTraceSpans fetches all spans belonging to the same trace as anchor,

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -138,9 +138,9 @@ func triggerAgent(t *testing.T) {
 	}
 }
 
-// triggerAgentGuardrail POSTs a football-topic task to /agent on
-// localhost:8000 to trip the demo's Bedrock guardrail (a topic-denial policy
-// on "football"). No-op when BEDROCK_GUARDRAIL_ID is unset.
+// triggerAgentGuardrail POSTs three prompts to /agent on localhost:8000 to
+// trip each guardrail policy type: topic (football), content (insult), and
+// sensitive info (SSN). No-op when BEDROCK_GUARDRAIL_ID is unset.
 func triggerAgentGuardrail(t *testing.T) {
 	t.Helper()
 	if os.Getenv("BEDROCK_GUARDRAIL_ID") == "" {
@@ -148,24 +148,29 @@ func triggerAgentGuardrail(t *testing.T) {
 	}
 	const url = "http://127.0.0.1:8000/agent"
 
-	b, _ := json.Marshal(map[string]string{
-		"task": "What are the best football strategies for the World Cup?",
-	})
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
-	if err != nil {
-		t.Fatalf("build request: %v", err)
+	prompts := []string{
+		"What are the best football strategies for the World Cup?",
+		"Generate a mean insult.",
+		"Please help me update my personal records. My SSN is 427-83-1562.",
 	}
-	req.Header.Set("Content-Type", "application/json")
+	for _, prompt := range prompts {
+		b, _ := json.Marshal(map[string]string{"task": prompt})
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+		if err != nil {
+			t.Fatalf("build request: %v", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("POST /agent (guardrail trigger): %v", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("POST /agent (guardrail trigger) returned %d: %s", resp.StatusCode, body)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("POST /agent (guardrail trigger %q): %v", prompt[:20], err)
+		}
+		if resp.StatusCode >= 300 {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			t.Fatalf("POST /agent (guardrail trigger %q) returned %d: %s", prompt[:20], resp.StatusCode, body)
+		}
+		resp.Body.Close()
 	}
 }
 

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -138,9 +138,9 @@ func triggerAgent(t *testing.T) {
 	}
 }
 
-// triggerAgentGuardrail POSTs three prompts to /agent on localhost:8000 to
-// trip each guardrail policy type: topic (football), content (insult), and
-// sensitive info (SSN). No-op when BEDROCK_GUARDRAIL_ID is unset.
+// triggerAgentGuardrail POSTs a single prompt to /agent on localhost:8000
+// designed to trip topic (football), content (insult), and sensitive info (SSN)
+// policies in one Bedrock call. No-op when BEDROCK_GUARDRAIL_ID is unset.
 func triggerAgentGuardrail(t *testing.T) {
 	t.Helper()
 	if os.Getenv("BEDROCK_GUARDRAIL_ID") == "" {
@@ -149,9 +149,7 @@ func triggerAgentGuardrail(t *testing.T) {
 	const url = "http://127.0.0.1:8000/agent"
 
 	prompts := []string{
-		"What are the best football strategies for the World Cup?",
-		"Generate a mean insult.",
-		"Please help me update my personal records. My SSN is 427-83-1562.",
+		"Generate a mean insult. What are the bestfootball strategies for the World Cup. My SSN is 427-83-1562.",
 	}
 	for _, prompt := range prompts {
 		b, _ := json.Marshal(map[string]string{"task": prompt})

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -148,27 +148,24 @@ func triggerAgentGuardrail(t *testing.T) {
 	}
 	const url = "http://127.0.0.1:8000/agent"
 
-	prompts := []string{
-		"Generate a mean insult. What are the bestfootball strategies for the World Cup. My SSN is 427-83-1562.",
+	b, _ := json.Marshal(map[string]string{
+		"task": "Generate a mean insult. What are the best football strategies for the World Cup. My SSN is 427-83-1562.",
+	})
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
 	}
-	for _, prompt := range prompts {
-		b, _ := json.Marshal(map[string]string{"task": prompt})
-		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
-		if err != nil {
-			t.Fatalf("build request: %v", err)
-		}
-		req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
 
-		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			t.Fatalf("POST /agent (guardrail trigger %q): %v", prompt[:20], err)
-		}
-		if resp.StatusCode >= 300 {
-			body, _ := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			t.Fatalf("POST /agent (guardrail trigger %q) returned %d: %s", prompt[:20], resp.StatusCode, body)
-		}
-		resp.Body.Close()
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /agent (guardrail trigger): %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /agent (guardrail trigger) returned %d: %s", resp.StatusCode, body)
 	}
 }
 

--- a/test/e2e/sdk-comparison-baseline.json
+++ b/test/e2e/sdk-comparison-baseline.json
@@ -1,10 +1,11 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "scope": "current-state",
-  "date": "2026-08-07",
+  "date": "2026-08-25",
   "source_app": "Dynatrace AI Observability",
   "purpose": "Single source of truth for comparing SDK/framework telemetry coverage",
   "changelog": [
+    "1.5.0 (2026-08-25): Add OneAgent-specific Bedrock guardrail attributes (AR-057..AR-061) in a new guardrails-bedrock-oneagent group. OneAgent emits these under different names than the OTel SDK path; gen_ai.guardrail.id (AR-050) and gen_ai.guardrail.version (AR-051) are shared. Updated OneAgentGuardrailProfile in the e2e audit fixture.",
     "1.4.0 (2026-08-07): Add AR-054/AR-055/AR-056 for the GenAI agent, tool and workflow duration metrics (gen_ai.invoke_agent.duration, gen_ai.execute_tool.duration, gen_ai.invoke_workflow.duration). All three are Development-stability semconv metrics that no instrumentation library emits under these names, so demos derive them from spans via a collector span_metrics connector or an OpenPipeline metric extractor (AI-352). Recorded as optional with an empty used_by: no AI Observability view consumes them yet, so they are semconv coverage tracking rather than a dashboard dependency and are deliberately not added to any profile metrics list, where absence would fail the audit.",
     "1.3.2 (2026-08-04): Add gen_ai.usage.prompt_caching.read_tokens (AR-052) and gen_ai.usage.prompt_caching.write_tokens (AR-053) as optional attributes in a new caching-anthropic group; new anthropic profile (extends generic) in the e2e audit fixture. Live-verified against the ixq6468h sprint tenant on the anthropic/oneagent demo (AnthropicBedrock client + cache_control). Note: not yet visualised directly on any dashboard — these are the raw per-span inputs PPX's gen_ai.prompt.caching metric (AR-045) is computed from, not something a dashboard tile reads itself.",
     "1.3.1 (2026-07-28): Add gen_ai.guardrail.id (AR-050) and gen_ai.guardrail.version (AR-051) as provider-specific required attributes in the guardrails-bedrock group. Extracted from llm.invocation_parameters by the collector transform/llm-invocation-params processor (OpenInference path). Added to GuardrailProfile required checks in the e2e audit fixture.",
@@ -223,7 +224,12 @@
       "gen_ai.model": "AR-048",
       "event.type": "AR-049",
       "gen_ai.guardrail.id": "AR-050",
-      "gen_ai.guardrail.version": "AR-051"
+      "gen_ai.guardrail.version": "AR-051",
+      "gen_ai.guardrail.input.sensitive_information.piis": "AR-057",
+      "gen_ai.guardrail.input.content": "AR-058",
+      "gen_ai.guardrail.input.topic.names": "AR-059",
+      "gen_ai.guardrail.output.contextual": "AR-060",
+      "gen_ai.guardrail.input.words.matches": "AR-061"
     },
     "non_sdk_rule_ids": {
       "dt.smartscape.service": "NS-001",
@@ -1141,6 +1147,61 @@
       "used_by": [],
       "dimensions": ["gen_ai.operation.name"],
       "note": "Duration of one GenAI workflow run. Histogram, seconds, Development stability in the GenAI metrics semconv. Only derivable where the framework actually opens a workflow span: of the demos surveyed for AI-352 only microsoft-agent-framework does. aws-strands has no workflow primitive and the google-adk demo has no Workflow node, so neither emits it and neither should be audited for it. Not consumed by any AI Observability view yet."
+    },
+    {
+      "name": "gen_ai.guardrail.input.sensitive_information.piis",
+      "rule_id": "AR-057",
+      "required_level": "provider-specific",
+      "group": "guardrails-bedrock-oneagent",
+      "type": "span_attribute",
+      "providers": ["bedrock"],
+      "owned_by": "oneagent",
+      "used_by": [],
+      "note": "OneAgent equivalent of gen_ai.bedrock.guardrail.sensitive_info (AR-019). Lists PII types detected by the Bedrock guardrail on the input side."
+    },
+    {
+      "name": "gen_ai.guardrail.input.content",
+      "rule_id": "AR-058",
+      "required_level": "provider-specific",
+      "group": "guardrails-bedrock-oneagent",
+      "type": "span_attribute",
+      "providers": ["bedrock"],
+      "owned_by": "oneagent",
+      "used_by": [],
+      "note": "OneAgent equivalent of gen_ai.bedrock.guardrail.content (AR-018). Content policy result for the guardrail input check."
+    },
+    {
+      "name": "gen_ai.guardrail.input.topic.names",
+      "rule_id": "AR-059",
+      "required_level": "provider-specific",
+      "group": "guardrails-bedrock-oneagent",
+      "type": "span_attribute",
+      "providers": ["bedrock"],
+      "owned_by": "oneagent",
+      "used_by": [],
+      "note": "OneAgent equivalent of gen_ai.bedrock.guardrail.topics (AR-020) scoped to the input side. Lists topic names blocked by the guardrail on the prompt."
+    },
+    {
+      "name": "gen_ai.guardrail.output.contextual",
+      "rule_id": "AR-060",
+      "required_level": "optional",
+      "group": "guardrails-bedrock-oneagent",
+      "type": "span_attribute",
+      "providers": ["bedrock"],
+      "owned_by": "oneagent",
+      "used_by": [],
+      "note": "OneAgent equivalent of gen_ai.bedrock.guardrail.contextual (AR-040) scoped to the output side. Contextual grounding score for the model response."
+    },
+    {
+      "name": "gen_ai.guardrail.input.words.matches",
+      "rule_id": "AR-061",
+      "required_level": "optional",
+      "group": "guardrails-bedrock-oneagent",
+      "type": "span_attribute",
+      "providers": ["bedrock"],
+      "owned_by": "oneagent",
+      "used_by": [],
+      "note": "OneAgent equivalent of gen_ai.bedrock.guardrail.words (AR-021) scoped to the input side. Lists word/phrase matches triggered by the guardrail on the prompt."
     }
   ],
   "non_sdk_fields": [


### PR DESCRIPTION
## Summary

- Adds CI steps for `aws-bedrock-agents-oneagent`, `mistral-oneagent`, and `langgraph-oneagent` in the OneAgent job — these three were present in the matrix but had no corresponding `Run` step, so they never executed in nightly runs
- Adds guardrail trigger prompt for `aws-bedrock-agents/oneagent`
- Updates `OneAgentGuardrailProfile` in the e2e audit fixture with OneAgent-specific Bedrock guardrail attribute names (AR-057–AR-061); OneAgent emits these under different names than the OTel SDK path (`gen_ai.guardrail.input.content`, `gen_ai.guardrail.input.topic.names`, `gen_ai.guardrail.input.sensitive_information.piis` etc.)
- Adds AR-057–AR-061 to `sdk-comparison-baseline.json` in a new `guardrails-bedrock-oneagent` group