### PR TITLE
fix: pass Azure OpenAI credentials to langgraph-oneagent e2e step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -382,6 +382,9 @@ jobs:
         env:
           TEST_RUN: TestLangGraphOneAgent
           OTEL_SERVICE_NAME: langgraph/oneagent
+          AZURE_OPENAI_ENDPOINT: ${{ secrets.AZURE_OPENAI_ENDPOINT }}
+          AZURE_OPENAI_API_KEY: ${{ secrets.AZURE_OPENAI_API_KEY }}
+          MODEL: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
         run: go test ./... -run "^${TEST_RUN}$" -v -timeout 20m
 
       # aws-strands-oneagent runs last: it appears to need more OneAgent sensor warm-up time than

--- a/langgraph/oneagent/main.py
+++ b/langgraph/oneagent/main.py
@@ -17,6 +17,8 @@ class HaikuState(TypedDict):
 
 
 def _build_graph():
+    # Credentials come from the environment (see .env.sample):
+    # AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, OPENAI_API_VERSION, MODEL.
     llm = AzureChatOpenAI(
         azure_deployment=os.environ.get("MODEL", "genai-demo"),
         azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),


### PR DESCRIPTION
## Problem

The nightly `oneagent-nightly` job fails at `TestLangGraphOneAgent`:

```
openai.OpenAIError: Missing credentials. Please pass one of `api_key`, ...
or the `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN` environment variables.
```

`langgraph/oneagent/main.py` reads `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `MODEL` (as documented in its `.env.sample`), but the `Run langgraph-oneagent` step only inherited the job-level `OPENAI_API_KEY` / `OPENAI_API_BASE`. `AzureChatOpenAI` was therefore constructed with `api_key=None`, every `POST /haiku` returned 500, `python3 -m json.tool` got an empty body ("Expecting value: line 1 column 1"), and `make request-secret` exited 2.

Not a code or instrumentation bug: no spans were produced because the app never reached the LLM call.

## Fix

Set the three vars the demo actually reads on that step, mirroring the existing `haystack-oneagent` step. `OPENAI_API_VERSION` is already exported at job level, so `main.py`'s lookup resolves.

Closes #269