### PR TITLE
pass bedrock guardrail creds to aws-strands e2e step

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -397,6 +397,8 @@ jobs:
         env:
           TEST_RUN: TestAWSStrandsOneAgent
           OTEL_SERVICE_NAME: aws-strands/oneagent
+          BEDROCK_GUARDRAIL_ID: ${{ secrets.BEDROCK_GUARDRAIL_ID }}
+          BEDROCK_GUARDRAIL_VERSION: ${{ secrets.BEDROCK_GUARDRAIL_VERSION }}
         run: go test ./... -run "^${TEST_RUN}$" -v -timeout 20m
 
       # Runs after all per-service steps to detect entity merging: if OneAgent


### PR DESCRIPTION

- Nightly `aws-strands-oneagent` step was missing `BEDROCK_GUARDRAIL_ID` and `BEDROCK_GUARDRAIL_VERSION`, so `triggerStrandsAgentGuardrail` ran with no guardrail configured — guardrail span never appeared, causing the guardrail audit profile to be skipped and only the generic profile to show up


