### PR TITLE
Add e2e coverage for Bedrock's standalone ApplyGuardrail API (aws-bedrock/openinference)

### DIFF
--- a/aws-bedrock/openinference/main.py
+++ b/aws-bedrock/openinference/main.py
@@ -77,6 +77,25 @@ def write_haiku(topic: str) -> str:
     return content[0]["text"] if content else "(blocked by guardrail)"
 
 
+def apply_guardrail(text: str) -> str:
+    """Calls Bedrock's standalone ApplyGuardrail API directly, rather than as part
+    of a Converse call. BedrockInstrumentor traces this as its own span with
+    openinference.span.kind = GUARDRAIL, distinct from the LLM-kind spans write_haiku
+    produces. Returns the guardrail action ("NONE" or "GUARDRAIL_INTERVENED"), or
+    "SKIPPED" when no guardrail is configured.
+    """
+    guardrail_id = os.environ.get("BEDROCK_GUARDRAIL_ID")
+    if not guardrail_id:
+        return "SKIPPED"
+    response = _get_client().apply_guardrail(
+        guardrailIdentifier=guardrail_id,
+        guardrailVersion=os.environ.get("BEDROCK_GUARDRAIL_VERSION", "DRAFT"),
+        source="INPUT",
+        content=[{"text": {"text": text}}],
+    )
+    return response.get("action", "NONE")
+
+
 def main():
     setup_instrumentation()
     print("=== Haiku Writer ===\n")

--- a/aws-bedrock/openinference/server.py
+++ b/aws-bedrock/openinference/server.py
@@ -4,7 +4,7 @@ import os
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from main import setup_instrumentation, write_haiku
+from main import apply_guardrail, setup_instrumentation, write_haiku
 
 setup_instrumentation()
 
@@ -20,6 +20,15 @@ class HaikuResponse(BaseModel):
     haiku: str
 
 
+class GuardrailRequest(BaseModel):
+    text: str
+
+
+class GuardrailResponse(BaseModel):
+    text: str
+    action: str
+
+
 @app.get("/health")
 def health():
     return {"status": "ok"}
@@ -31,3 +40,11 @@ async def haiku(req: HaikuRequest):
         raise HTTPException(status_code=400, detail="topic must not be empty")
     result = await asyncio.to_thread(write_haiku, req.topic)
     return HaikuResponse(topic=req.topic, haiku=result)
+
+
+@app.post("/guardrail", response_model=GuardrailResponse)
+async def guardrail(req: GuardrailRequest):
+    if not req.text.strip():
+        raise HTTPException(status_code=400, detail="text must not be empty")
+    result = await asyncio.to_thread(apply_guardrail, req.text)
+    return GuardrailResponse(text=req.text, action=result)

--- a/test/e2e/aws_bedrock_openinference_test.go
+++ b/test/e2e/aws_bedrock_openinference_test.go
@@ -8,6 +8,7 @@ func TestAWSBedrockOpenInference(t *testing.T) {
 	startApp(t, "aws-bedrock/openinference")
 	triggerHaiku(t, true)
 	triggerHaikuGuardrail(t)
+	triggerApplyGuardrail(t)
 
 	// triggerHaiku and triggerHaikuGuardrail each produce their own trace.
 	// sort + limit pins the baseline audit to the earlier (non-guardrail)
@@ -34,4 +35,14 @@ func TestAWSBedrockOpenInference(t *testing.T) {
 | sort start_time desc
 | limit 1`,
 		"aws-bedrock/openinference", genAIClientMetrics)
+
+	// triggerApplyGuardrail's two calls (safe, then trigger) each produce their
+	// own GUARDRAIL-kind span; sort + limit pins this audit to the later
+	// (triggering) one deterministically.
+	auditApplyGuardrailSpan(t, "aws-bedrock", "openinference",
+		`fetch spans, from: now()-10m
+| filter service.name == "aws-bedrock/openinference"
+| filter gen_ai.operation.name == "GUARDRAIL"
+| sort start_time desc
+| limit 1`)
 }

--- a/test/e2e/fixture_audit_test.go
+++ b/test/e2e/fixture_audit_test.go
@@ -142,6 +142,40 @@ var GuardrailProfile = Profile{
 	},
 }
 
+// ApplyGuardrailProfile checks Bedrock's standalone ApplyGuardrail API
+// (client.apply_guardrail), which openinference-instrumentation-bedrock traces as
+// its own OpenInference "GUARDRAIL"-kind span — structurally distinct from the
+// Converse guardrailConfig path GuardrailProfile checks. It intentionally does NOT
+// check gen_ai.bedrock.guardrail.{content,topics,words,sensitive_info} the way
+// GuardrailProfile does: the ApplyGuardrail wrapper never puts that assessment
+// breakdown into span attributes at all (only action/actionReason/outputs), so
+// there's nothing for a collector transform to reconstruct it from. It also does
+// not check for a gen_ai.bedrock.guardrail.* / gen_ai.guardrail.id projection more
+// generally — genainormalizer's "openinference" source has no such mapping (its
+// LookupTable only renames LLM-kind model/token/tool/agent/session attributes; see
+// genainormalizerprocessor/internal/openinference/mappings.go upstream), and no
+// collector config in this repo adds one for aws-bedrock/openinference either
+// (sdk-comparison-baseline.md documents gen_ai.guardrail.id as "extracted from
+// llm.invocation_parameters by the collector transform/llm-invocation-params
+// processor (OpenInference path)", but no such processor exists anywhere in this
+// repo — that line is aspirational baseline, not shipped normalization). So this
+// profile checks the raw OpenInference span/IO attributes the wrapper actually
+// sets. Note that openinference.span.kind itself does not survive as-is: the
+// generic LookupTable renames it to gen_ai.operation.name (with remove_originals
+// dropping the original), so the DQL anchor query for this profile must filter on
+// gen_ai.operation.name == "GUARDRAIL", not openinference.span.kind.
+var ApplyGuardrailProfile = Profile{
+	Name: "bedrock-apply-guardrail",
+	Required: []AttributeCheck{
+		{Name: "gen_ai.operation.name"},
+		{Name: "output.value"},
+		{Name: "metadata"},
+	},
+	Optional: []AttributeCheck{
+		{Name: "input.value"},
+	},
+}
+
 var OneAgentGuardrailProfile = Profile{
 	Name: "oneagent-bedrock-guardrail",
 	Required: []AttributeCheck{
@@ -584,6 +618,47 @@ func auditGuardrailSpan(t *testing.T, sdk, instrumentation, dql string, note ...
 func auditOneAgentGuardrailSpan(t *testing.T, sdk, instrumentation, dql string, note ...string) {
 	t.Helper()
 	auditSpanOptional(t, sdk, instrumentation+"-guardrail", OneAgentGuardrailProfile, dql, note...)
+}
+
+// auditApplyGuardrailSpan audits the guardrail-triggering call from
+// triggerApplyGuardrail against ApplyGuardrailProfile. It cannot reuse
+// auditSpanOptional/auditGuardrailSpan: _apply_guardrail_wrapper
+// (openinference-instrumentation-bedrock) sets the span's OTel status to ERROR
+// when the guardrail actually blocks content — the expected, asserted-for outcome
+// here — whereas every other audit helper in this file treats
+// span.status_code == "error" as a failure via assertNotErrorSpan. Skips (rather
+// than fails) when no anchor span is found, since triggerApplyGuardrail no-ops
+// when BEDROCK_GUARDRAIL_ID is unset. Reports are written under
+// "<instrumentation>-apply-guardrail" so they never collide with the baseline or
+// GuardrailProfile reports for the same suite.
+func auditApplyGuardrailSpan(t *testing.T, sdk, instrumentation, dql string, note ...string) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), spanPollTimeout())
+	defer cancel()
+
+	records, err := dtClient.PollUntilSpans(ctx, scopedDQL(dql), 15*time.Second)
+	if err != nil || len(records) == 0 {
+		t.Skipf("no %s/%s apply_guardrail spans found — guardrail likely not configured this run", sdk, instrumentation)
+		return
+	}
+	if v, ok := records[0]["span.status_code"]; !ok || fmt.Sprint(v) != "error" {
+		t.Fatalf("expected the guardrail-triggering apply_guardrail span to have span.status_code=error (guardrail should have blocked the request): %v", records[0])
+	}
+
+	spans := fetchTraceSpans(t, ctx, records[0])
+	report := buildReport(sdk, instrumentation+"-apply-guardrail", ApplyGuardrailProfile, mergeSpans(spans))
+	if len(note) > 0 {
+		report.Note = note[0]
+	}
+	writeReport(t, report)
+
+	for _, r := range report.Required {
+		if r.Status == "fail" {
+			t.Logf("required attribute missing [%s] %s", r.RuleID, r.Attribute)
+		}
+	}
+	t.Logf("audit verdict: %s (%d spans in trace) — report written to reports/%s-%s.{json,md}",
+		report.Verdict, len(spans), sdk, instrumentation+"-apply-guardrail")
 }
 
 // fetchTraceSpans fetches all spans belonging to the same trace as anchor,

--- a/test/e2e/fixture_triggers_test.go
+++ b/test/e2e/fixture_triggers_test.go
@@ -112,6 +112,53 @@ func triggerHaikuGuardrail(t *testing.T) {
 	}
 }
 
+type guardrailCheck struct {
+	Text string `json:"text"`
+}
+
+// triggerApplyGuardrail POSTs two requests to /guardrail on localhost:8000,
+// exercising Bedrock's standalone ApplyGuardrail API (client.apply_guardrail) —
+// structurally distinct from the Converse guardrailConfig path exercised by
+// triggerHaikuGuardrail: it produces its own OpenInference "GUARDRAIL"-kind span
+// rather than an LLM-kind span, and isn't a chat completion at all (no model, no
+// generated text). The first call sends guardrail-safe content; the second reuses
+// the "football strategies for the World Cup" topic-denial trigger already used
+// by triggerHaikuGuardrail to trip the same guardrail resource, mirroring the
+// non-guardrail/guardrail-triggering split. No-op when BEDROCK_GUARDRAIL_ID is
+// unset, matching the app-side skip behavior.
+func triggerApplyGuardrail(t *testing.T) {
+	t.Helper()
+	if os.Getenv("BEDROCK_GUARDRAIL_ID") == "" {
+		return
+	}
+	postGuardrailCheck(t, "Who is the president of the United States?")
+	postGuardrailCheck(t, "What are the best football strategies for the World Cup?")
+}
+
+// postGuardrailCheck POSTs a single text to /guardrail on localhost:8000.
+func postGuardrailCheck(t *testing.T, text string) {
+	t.Helper()
+	const url = "http://127.0.0.1:8000/guardrail"
+
+	b, _ := json.Marshal(guardrailCheck{Text: text})
+	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(b))
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /guardrail: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 300 {
+		rb, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /guardrail returned %d: %s", resp.StatusCode, rb)
+	}
+}
+
 // triggerAgent POSTs a task to /agent on localhost:8000.
 func triggerAgent(t *testing.T) {
 	t.Helper()


### PR DESCRIPTION
## Summary

- Adds a code path in `aws-bedrock/openinference` that calls Bedrock's standalone `ApplyGuardrail` API (`client.apply_guardrail`) directly, exposed via a new `POST /guardrail` endpoint, reusing the same `BEDROCK_GUARDRAIL_ID`/`BEDROCK_GUARDRAIL_VERSION` configuration as the existing Converse `guardrailConfig` path.
- This is a structurally different call from Converse: `openinference-instrumentation-bedrock` traces it as its own span with OpenInference span kind `GUARDRAIL` (no model, no generated text), and the wrapper sets the span's OTel status to `ERROR` when the guardrail actually blocks the request — a clean, reliable trigger/no-trigger signal, unlike some of the other guardrail paths in this repo.
- Adds a new e2e trigger (`triggerApplyGuardrail`) that sends one guardrail-safe request and one guardrail-triggering request (reusing the existing "football" trigger topic), mirroring the non-guardrail/guardrail-triggering split already used for the Converse guardrail test.
- Adds a new audit profile (`ApplyGuardrailProfile`) and a dedicated audit helper, since the existing guardrail audit helpers treat an `ERROR`-status span as a failure — here it's the expected outcome.
- Does not touch `aws-bedrock/oneagent`: OneAgent auto-instruments the boto3 call regardless of which Bedrock API is used, so this gap is specific to the OpenInference instrumentation path.

## Test plan

- [ ] CI (`.github/workflows/e2e.yml`) runs `TestAWSBedrockOpenInference` on this PR and it passes
- [ ] Manually verify in Dynatrace that the guardrail-triggering `apply_guardrail` span carries `gen_ai.operation.name = "GUARDRAIL"`, `output.value`, and `metadata`, and has `span.status_code = error`