### PR TITLE
Fix empty gen_ai message parts in aws-bedrock/openinference

### DIFF
--- a/aws-bedrock/openinference/README.md
+++ b/aws-bedrock/openinference/README.md
@@ -10,12 +10,22 @@ OpenInference uses its own semantic conventions (`llm.model_name`, `llm.token_co
 App  ->  Bindplane collector (genainormalizer + transform)  ->  Dynatrace Grail
 ```
 
-The app knows only about `http://localhost:4318`; the collector is the component that authenticates with Dynatrace (`DT_ENDPOINT`, `DT_API_TOKEN`) and forwards spans. The pipeline runs two processors (see [`otelcol-config.yaml`](otelcol-config.yaml)):
+The app knows only about `http://localhost:4318`; the collector is the component that authenticates with Dynatrace (`DT_ENDPOINT`, `DT_API_TOKEN`) and forwards spans. The pipeline runs these processors (see [`otelcol-config.yaml`](otelcol-config.yaml)):
 
-1. **`gen_ai_normalizer`** (source `openinference`, `remove_originals: true`) maps OpenInference attributes to `gen_ai.*` and reconstructs the flattened `llm.input_messages.N.*` / `llm.output_messages.N.*` attributes into `gen_ai.input.messages` and `gen_ai.output.messages` JSON. `remove_originals` drops the raw `llm.*` attributes so exported spans carry only `gen_ai.*` fields.
-2. **`transform/response_model`** mirrors `gen_ai.request.model` to `gen_ai.response.model`, which the AI Observability app requires and OpenInference has no separate field for.
+1. **`gen_ai_normalizer`** (source `openinference`, `remove_originals: false`) maps OpenInference attributes to `gen_ai.*` and reconstructs the flattened `llm.input_messages.N.*` / `llm.output_messages.N.*` attributes into `gen_ai.input.messages` and `gen_ai.output.messages` JSON.
+2. **`transform/fix_input_messages`** / **`transform/fix_output_messages`** rebuild `gen_ai.input.messages` / `gen_ai.output.messages` by hand — `gen_ai_normalizer` otherwise emits both with an empty `parts` array for this demo; see [Known gaps & limitations](#known-gaps--limitations) below.
+3. **`transform/response_model`** mirrors `gen_ai.request.model` to `gen_ai.response.model`, which the AI Observability app requires and OpenInference has no separate field for.
+4. **`transform/cleanup_raw_attrs`** strips the raw `llm.*` attributes left behind by turning off `remove_originals`, so exported spans still end up `gen_ai.*`-only.
 
 The collector is pinned to `ghcr.io/observiq/bindplane-agent:1.104.0` (Bindplane Distro for OpenTelemetry), which tracks OTel Collector contrib v0.156.0 and bundles the `genainormalizer` processor. The pin means a future version bump surfaces normalization changes in the e2e test.
+
+## Known gaps & limitations
+
+### genainormalizer drops message content (worked around locally)
+
+`genainormalizer`'s `openinference` source reconstructs `gen_ai.input.messages` and `gen_ai.output.messages` with an empty `parts` array for every span this demo produces — [upstream issue](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50133). The root cause: Bedrock's `converse` API takes `content` as an array even for a single plain-text block, so `openinference-instrumentation-bedrock` never sets the flat `message.content` string the normalizer's message-reconstruction path expects — it only nests text under the indexed `llm.{input,output}_messages.N.message.contents.M.message_content.*` form. Unlike the direct-Anthropic-SDK case (see `anthropic/openinference`'s README), this hits *both* input and output messages here, since `system` and user turns all go through the same array-shaped `content` field.
+
+Worked around with hand-written `transform/fix_input_messages` / `transform/fix_output_messages` processors in [`otelcol-config.yaml`](otelcol-config.yaml) that rebuild both attributes from the raw `llm.*` attributes after `genainormalizer` runs (`remove_originals` is turned off, and `transform/cleanup_raw_attrs` strips the raw attributes afterward instead). This only handles the single `"text"`-type content block per message that `write_haiku` produces (`llm.input_messages.0` = system prompt, `.1` = user message, `llm.output_messages.0` = assistant reply) — multiple content blocks or a tool call would need a corresponding statement added, and would otherwise fall back to `genainormalizer`'s empty-parts version. Remove this workaround once the upstream fix is merged and available in the pinned collector image.
 
 ## Prerequisites
 

--- a/aws-bedrock/openinference/otelcol-config.yaml
+++ b/aws-bedrock/openinference/otelcol-config.yaml
@@ -11,12 +11,54 @@ processors:
   # The built-in "openinference" source maps model, provider, token usage, tool,
   # agent and session attributes, and reconstructs the flattened
   # llm.input_messages.N.* / llm.output_messages.N.* into gen_ai.input.messages
-  # and gen_ai.output.messages. remove_originals drops the raw llm.* attributes
-  # so the exported spans carry only gen_ai.* fields.
+  # and gen_ai.output.messages. remove_originals is off (unlike before) because
+  # transform/fix_input_messages and transform/fix_output_messages below need
+  # the raw llm.* attributes still present after this runs;
+  # transform/cleanup_raw_attrs strips them at the end of the pipeline instead
+  # so the exported spans still end up gen_ai.*-only.
   gen_ai_normalizer:
     sources:
       - name: openinference
-        remove_originals: true
+        remove_originals: false
+
+  # gen_ai_normalizer reconstructs gen_ai.input.messages / gen_ai.output.messages
+  # with empty `parts` here: Bedrock's converse API takes `content` as an array
+  # even for a single plain-text block, so openinference-instrumentation-bedrock
+  # always nests message text under
+  # llm.{input,output}_messages.N.message.contents.M.message_content.* (a
+  # content-block array) and never sets the flat .message.content string the
+  # normalizer's message path expects. Upstream bug:
+  # https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50133
+  # Rebuild both by hand from the raw attributes for the single-text-block
+  # shape this demo produces (llm.input_messages.0 = system prompt,
+  # .1 = user message, llm.output_messages.0 = assistant reply); a response
+  # with multiple content blocks or a tool call needs a corresponding
+  # statement added here, and would otherwise keep the normalizer's
+  # empty-parts version. Remove once the fix for the upstream issue is merged
+  # and available in the collector image.
+  transform/fix_input_messages:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - 'set(attributes["gen_ai.input.messages"], [{"role": attributes["llm.input_messages.0.message.role"], "parts": [{"type": "text", "content": attributes["llm.input_messages.0.message.contents.0.message_content.text"]}]}, {"role": attributes["llm.input_messages.1.message.role"], "parts": [{"type": "text", "content": attributes["llm.input_messages.1.message.contents.0.message_content.text"]}]}]) where attributes["llm.input_messages.1.message.contents.0.message_content.type"] == "text"'
+
+  transform/fix_output_messages:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - 'set(attributes["gen_ai.output.messages"], [{"role": attributes["llm.output_messages.0.message.role"], "parts": [{"type": "text", "content": attributes["llm.output_messages.0.message.contents.0.message_content.text"]}], "finish_reason": attributes["llm.finish_reason"]}]) where attributes["llm.output_messages.0.message.contents.0.message_content.type"] == "text"'
+
+  # Drops the raw llm.* attributes that gen_ai_normalizer left in place (see
+  # above) so exported spans carry only gen_ai.* fields, same end result as
+  # remove_originals: true would have given.
+  transform/cleanup_raw_attrs:
+    error_mode: ignore
+    trace_statements:
+      - context: span
+        statements:
+          - delete_matching_keys(attributes, "^llm\\..*")
 
   # gen_ai_normalizer maps llm.model_name -> gen_ai.request.model but does not
   # emit gen_ai.response.model (OpenInference has no separate response-model
@@ -112,14 +154,14 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [gen_ai_normalizer, transform/response_model, batch]
+      processors: [gen_ai_normalizer, transform/fix_input_messages, transform/fix_output_messages, transform/response_model, transform/cleanup_raw_attrs, batch]
       exporters: [otlp_http/dynatrace]
     # Second branch of the same spans: normalize, keep only LLM spans, and feed
     # the metric connectors. Kept separate from the export pipeline so the filter
     # here never drops spans from Distributed Tracing.
     traces/genai_metrics:
       receivers: [otlp]
-      processors: [gen_ai_normalizer, transform/response_model, filter/genai_only, batch]
+      processors: [gen_ai_normalizer, transform/fix_input_messages, transform/fix_output_messages, transform/response_model, transform/cleanup_raw_attrs, filter/genai_only, batch]
       exporters: [span_metrics, signal_to_metrics]
     metrics:
       receivers: [otlp, span_metrics, signal_to_metrics]


### PR DESCRIPTION
## Summary
- `genainormalizer`'s `openinference` source emits `gen_ai.input.messages` / `gen_ai.output.messages` with empty `parts` for this demo: Bedrock's `converse` API always sends `content` as an array (even for a single plain-text block), so `openinference-instrumentation-bedrock` never sets the flat `message.content` string the normalizer's reconstruction path expects — see [open-telemetry/opentelemetry-collector-contrib#50133](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/50133).
- Adds `transform/fix_input_messages` / `transform/fix_output_messages` processors to `otelcol-config.yaml` that rebuild both attributes by hand from the raw `llm.*` attributes after `genainormalizer` runs, plus `transform/cleanup_raw_attrs` to strip the raw attributes afterward (mirrors the workaround already shipped in `anthropic/openinference`).
- Documents the gap and the workaround in a new "Known gaps & limitations" section in the README.

Follow-up to review feedback on #254 ([comment](https://github.com/dynatrace-oss/dynatrace-ai-agent-instrumentation-examples/pull/254#issuecomment-5489189903)), which flagged the same normalizer bug for the direct-Anthropic-SDK demo — it turned out to affect this Bedrock demo too, and more broadly (both input and output messages, not just output).

## Test plan
- [x] `otelcol-config.yaml` YAML-parses cleanly
- [x] Verified live against the pinned collector image (`ghcr.io/observiq/bindplane-agent:1.107.0`) in a local Docker container: sent a synthetic span with this demo's exact attribute shape and confirmed `gen_ai.input.messages` / `gen_ai.output.messages` now populate `parts` correctly, with no raw `llm.*` attributes left behind
- [ ] e2e test passes in CI