### PR TITLE
e2e: exclude ask-guardrail spans from pydantic-ai bedrock audit query

### DIFF
--- a/test/e2e/pydantic_ai_opentelemetry_test.go
+++ b/test/e2e/pydantic_ai_opentelemetry_test.go
@@ -6,8 +6,10 @@ import (
 
 func TestPydanticAIOpenTelemetry(t *testing.T) {
 	startAppWithTarget(t, "pydantic-ai/opentelemetry", "run-collector")
-	// Fire 3 requests so the random provider selection covers both Azure and Bedrock.
-	for range 3 {
+	// Fire 6 requests so the random provider selection covers both Azure and Bedrock.
+	// With 3 requests, the odds of missing Bedrock entirely by chance are ~3.7%
+	// (1/3 per request); 6 requests brings that down to ~0.1%.
+	for range 6 {
 		triggerMusicAgent(t)
 	}
 	triggerMusicAgentGuardrail(t)

--- a/test/e2e/pydantic_ai_opentelemetry_test.go
+++ b/test/e2e/pydantic_ai_opentelemetry_test.go
@@ -13,12 +13,22 @@ func TestPydanticAIOpenTelemetry(t *testing.T) {
 	triggerMusicAgentGuardrail(t)
 
 	t.Run("bedrock", func(t *testing.T) {
+		// gen_ai.provider.name/gen_ai.system == "AWS Bedrock" also matches spans from the
+		// ask-guardrail flow (always Bedrock Haiku, no temperature, and without usage tokens
+		// on a guardrail-intervened response) — excluded here via a trace-id lookup so this
+		// audits the /api/ask flow only. The guardrail flow has its own "bedrock-guardrail" subtest below.
 		auditSpanOptionalWithMetrics(t, "pydantic-ai", "opentelemetry-bedrock", GenericProfile,
 			`fetch spans, from: now()-10m
 | filter service.name == "pydantic-ai-music-agent"
 | filter gen_ai.provider.name == "AWS Bedrock" or gen_ai.system == "AWS Bedrock"
 | filter isNotNull(gen_ai.request.model)
 | filter isNull(span.status_code) or span.status_code != "error"
+| lookup [fetch spans, from: now()-10m
+    | filter service.name == "pydantic-ai-music-agent"
+    | filter isNotNull(gen_ai.guardrail.id)
+    | fields trace.id],
+  sourceField: trace.id, lookupField: trace.id
+| filter isNull(lookup.trace.id)
 | limit 1`,
 			"pydantic-ai-music-agent", genAIClientMetrics)
 	})


### PR DESCRIPTION
## Summary

Fixes the false attribute regression reported by the nightly alert bot (issue #297), with two complementary changes:

1. **DQL fix.** The `bedrock` subtest in `test/e2e/pydantic_ai_opentelemetry_test.go` audits `/api/ask` spans routed to AWS Bedrock (provider is picked at random per request). Its DQL filter (`gen_ai.provider.name == "AWS Bedrock" or gen_ai.system == "AWS Bedrock"`) also matches spans from the separate `/api/ask-guardrail` flow, which always targets Bedrock Haiku but never sets a `temperature` and — on a guardrail-intervened response — has no usage tokens either. On a night where the random provider shuffle for `/api/ask` doesn't happen to land on Bedrock, the only Bedrock-tagged trace left in the query window is the guardrail one, so the query picks it up and the audit reports `gen_ai.usage.input_tokens`/`gen_ai.usage.output_tokens`/`gen_ai.request.temperature` as missing — a false regression, not a real one. This adds a `lookup` to exclude any trace that also contains a span with `gen_ai.guardrail.id` set, so the `bedrock` subtest only ever considers genuine `/api/ask` traces. The guardrail flow keeps its own dedicated `bedrock-guardrail` subtest below, unaffected by this change.

2. **Sample size.** `/api/ask` picks a provider via `random.shuffle` over 3 builders (Azure, Bedrock Sonnet, Bedrock Haiku) and returns on the first that succeeds — a flat 1/3 chance per provider per call. Firing only 3 requests means there's a ~3.7% chance per nightly run that Bedrock never gets selected at all (all 3 land on Azure), leaving the `bedrock` subtest with nothing to audit — which is very likely what triggered issue #297 in the first place (confirmed live: that night's only Bedrock-tagged trace was the guardrail one, no genuine Bedrock `/api/ask` trace existed). Bumping to 6 requests cuts that probability to ~0.1%.

## Verification

Queried the sprint tenant directly for the exact window the regression alert flagged: the only Bedrock-tagged trace present was the ask-guardrail one (no genuine Bedrock `/api/ask` trace occurred that night). Running the updated query against that same data returns zero records, which correctly skips the subtest (`no ... spans found — provider likely not selected this run`) instead of reporting a regression. Also checked for exception span events on the service over a 48h window — none found — ruling out Bedrock silently failing and falling back to Azure as an alternate explanation.

## Test plan

- [x] `go vet ./test/e2e/...` passes
- [x] `gofmt -l` clean
- [ ] Confirm the next nightly run no longer flags this suite when Bedrock isn't randomly selected for `/api/ask`
- [ ] Confirm the `bedrock` subtest still reports correctly on a night when Bedrock *is* selected for `/api/ask`
