### PR TITLE
Summarize attribute changes vs. nightly baseline in PR span-audit comment

### DIFF
--- a/.github/scripts/download-nightly-baseline.sh
+++ b/.github/scripts/download-nightly-baseline.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Downloads the span-audit-report artifacts from the most recently completed
+# nightly (schedule-triggered) e2e run on main, so pr-attribute-diff.sh can
+# diff this PR's attribute results against that baseline.
+#
+# Required env: GH_TOKEN, REPO
+# Optional env: BASELINE_DIR (default: baseline-reports)
+# Outputs (GITHUB_OUTPUT): run_id, run_url — left unset if no baseline was found
+set -euo pipefail
+
+REPO="${REPO:?REPO is required}"
+BASELINE_DIR="${BASELINE_DIR:-baseline-reports}"
+mkdir -p "$BASELINE_DIR"
+
+RUN_JSON=$(gh api \
+  "repos/${REPO}/actions/workflows/e2e.yml/runs?event=schedule&branch=main&status=completed&per_page=1" \
+  --jq '.workflow_runs[0] // empty')
+
+if [ -z "$RUN_JSON" ]; then
+  echo "No completed nightly run found on main; skipping baseline diff."
+  exit 0
+fi
+
+RUN_ID=$(echo "$RUN_JSON" | jq -r '.id')
+RUN_URL=$(echo "$RUN_JSON" | jq -r '.html_url')
+echo "Baseline nightly run: ${RUN_ID} (${RUN_URL})"
+
+if ! gh run download "$RUN_ID" --repo "$REPO" --dir "$BASELINE_DIR" --pattern 'span-audit-reports-*' 2>/dev/null; then
+  echo "Warning: failed to download baseline artifacts for run ${RUN_ID} (may have expired)"
+  exit 0
+fi
+
+# gh run download puts each matched artifact in its own subdirectory; flatten
+# so pr-attribute-diff.sh can glob *.json directly in BASELINE_DIR.
+find "$BASELINE_DIR" -mindepth 2 -name '*.json' -exec mv {} "$BASELINE_DIR" \;
+
+{
+  echo "run_id=${RUN_ID}"
+  echo "run_url=${RUN_URL}"
+} >> "$GITHUB_OUTPUT"

--- a/.github/scripts/pr-attribute-diff.sh
+++ b/.github/scripts/pr-attribute-diff.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Emits a markdown fragment summarizing attribute-level changes between this
+# run's span-audit reports and the baseline (last completed nightly run on
+# main), so PR reviewers see new / regressed gen_ai.* attributes without
+# digging through the full per-suite tables. Written to stdout; the caller
+# appends it into the PR comment body.
+#
+# Reports are matched by filename (`<sdk>-<instrumentation>.json`). An
+# attribute only counts as changed if its detection status flips between an
+# ok status (pass/pass_via_fallback/present/present_via_fallback) and a bad
+# one (fail/absent), in either direction — a rule added or removed by the PR
+# itself that was never/still isn't observed doesn't show up.
+#
+# Inputs (environment variables):
+#   CURR_DIR     - directory with this run's *.json span-audit reports
+#   BASELINE_DIR - directory with the baseline nightly run's *.json reports
+set -euo pipefail
+
+CURR_DIR="${CURR_DIR:-all-reports}"
+BASELINE_DIR="${BASELINE_DIR:-baseline-reports}"
+
+if [ ! -d "$BASELINE_DIR" ] || [ -z "$(find "$BASELINE_DIR" -maxdepth 1 -name '*.json' 2>/dev/null)" ]; then
+  echo "_No nightly baseline available to diff attributes against._"
+  exit 0
+fi
+
+ALL_ROWS=""
+while IFS= read -r curr_file; do
+  filename=$(basename "$curr_file")
+  prev_file=$(find "$BASELINE_DIR" -maxdepth 1 -name "$filename" | head -1)
+  [ -n "$prev_file" ] && [ -f "$prev_file" ] || continue
+
+  ROWS=$(jq -r '
+    def was_ok: test("^(pass|pass_via_fallback|present|present_via_fallback)$");
+    def is_bad: test("^(fail|absent)$");
+    def attrs: (.required + .optional + ([.metrics[]? | {attribute: .metric, status: .status}]))
+      | map({key: .attribute, value: .status}) | from_entries;
+    . as $curr | input as $prev |
+    ($curr | attrs) as $c | ($prev | attrs) as $p |
+    (($c | keys) + ($p | keys) | unique) as $names |
+    $names[] as $name |
+    ($c[$name]) as $cs | ($p[$name]) as $ps |
+    if ($ps != null and ($ps | was_ok) and ($cs == null or ($cs | is_bad))) then
+      "REMOVED\t\($curr.sdk)/\($curr.instrumentation)\t\($name)\t\($ps)\t\($cs // "not tracked")"
+    elif (($ps == null or ($ps | is_bad)) and $cs != null and ($cs | was_ok)) then
+      "ADDED\t\($curr.sdk)/\($curr.instrumentation)\t\($name)\t\($ps // "not tracked")\t\($cs)"
+    else empty end
+  ' "$curr_file" "$prev_file" 2>/dev/null || true)
+
+  [ -n "$ROWS" ] && ALL_ROWS="${ALL_ROWS}${ROWS}"$'\n'
+done < <(find "$CURR_DIR" -maxdepth 1 -name '*.json' | sort)
+
+ALL_ROWS="${ALL_ROWS%$'\n'}"
+
+if [ -z "$ALL_ROWS" ]; then
+  echo "No attribute changes vs. the last nightly run on \`main\`."
+  exit 0
+fi
+
+print_table() {
+  local label="$1" rows="$2"
+  [ -z "$rows" ] && return
+  echo "**${label}**"
+  echo
+  echo "| Suite | Attribute | Before | Now |"
+  echo "|-------|-----------|--------|-----|"
+  echo "$rows" | awk -F'\t' '{printf "| `%s` | `%s` | %s | %s |\n", $2, $3, $4, $5}'
+  echo
+}
+
+print_table "➕ Added" "$(echo "$ALL_ROWS" | awk -F'\t' '$1=="ADDED"')"
+print_table "➖ Removed" "$(echo "$ALL_ROWS" | awk -F'\t' '$1=="REMOVED"')"

--- a/.github/scripts/pr-audit-comment.sh
+++ b/.github/scripts/pr-audit-comment.sh
@@ -12,13 +12,19 @@
 #                         tick in the summary, plus a link to the run for the detail.
 #
 # Inputs (environment variables):
-#   RUN_URL     - URL of this Actions run (linked in the overflow case)
-#   REPORTS_DIR - directory containing the merged *.md / *.json reports
-#   OUTPUT_FILE - path to write the comment body to (default: comment.md)
+#   RUN_URL          - URL of this Actions run (linked in the overflow case)
+#   REPORTS_DIR      - directory containing the merged *.md / *.json reports
+#   BASELINE_DIR     - directory containing the baseline nightly run's *.json
+#                      reports, downloaded by download-nightly-baseline.sh
+#                      (default: baseline-reports)
+#   BASELINE_RUN_URL - URL of the baseline nightly run, for linking (optional)
+#   OUTPUT_FILE      - path to write the comment body to (default: comment.md)
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 THRESHOLD=2
 REPORTS_DIR="${REPORTS_DIR:-all-reports}"
+BASELINE_DIR="${BASELINE_DIR:-baseline-reports}"
 OUTPUT_FILE="${OUTPUT_FILE:-comment.md}"
 
 # Collect report basenames (one per suite) from the JSON files, sorted for a
@@ -36,6 +42,23 @@ body_file="$OUTPUT_FILE"
   echo "## 🔭 GenAI span audit"
   echo
 } > "$body_file"
+
+if [ "$count" -gt 0 ]; then
+  {
+    echo "### 📊 Attribute changes vs. nightly (\`main\`)"
+    echo
+    if [ -n "${BASELINE_RUN_URL:-}" ]; then
+      echo "_Baseline: [last nightly run](${BASELINE_RUN_URL})._"
+      echo
+    fi
+  } >> "$body_file"
+  CURR_DIR="$REPORTS_DIR" BASELINE_DIR="$BASELINE_DIR" bash "${SCRIPT_DIR}/pr-attribute-diff.sh" >> "$body_file"
+  {
+    echo
+    echo "---"
+    echo
+  } >> "$body_file"
+fi
 
 verdict_tick() {
   case "$1" in

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -565,6 +565,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      actions: read
     steps:
       - name: Checkout
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
@@ -578,10 +579,21 @@ jobs:
           path: all-reports/
         continue-on-error: true
 
+      - name: Download nightly baseline reports
+        id: baseline
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BASELINE_DIR: baseline-reports
+        run: bash .github/scripts/download-nightly-baseline.sh
+        continue-on-error: true
+
       - name: Build comment body
         env:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           REPORTS_DIR: all-reports
+          BASELINE_DIR: baseline-reports
+          BASELINE_RUN_URL: ${{ steps.baseline.outputs.run_url }}
           OUTPUT_FILE: comment.md
         run: bash .github/scripts/pr-audit-comment.sh
 

--- a/test/e2e/openai_openinference_test.go
+++ b/test/e2e/openai_openinference_test.go
@@ -9,7 +9,19 @@ func TestOpenAIOpenInference(t *testing.T) {
 	// No triggerHaiku — the haiku request is issued by make run itself.
 	startCLIApp(t, "openai/openinference")
 
-	auditSpanWithMetrics(t, "openai", "openinference", OpenAIProfile,
+	// TEMPORARY: drop the gen_ai.operation.name optional check (AR-008) to
+	// exercise the new PR attribute-diff feature against the nightly
+	// baseline on main. Revert before merging.
+	profile := OpenAIProfile
+	var optional []AttributeCheck
+	for _, c := range profile.Optional {
+		if c.RuleID != "AR-008" {
+			optional = append(optional, c)
+		}
+	}
+	profile.Optional = optional
+
+	auditSpanWithMetrics(t, "openai", "openinference", profile,
 		`fetch spans, from: now()-10m
 | filter service.name == "openai/openinference"
 | filter isNotNull(gen_ai.request.model)

--- a/test/e2e/openai_openinference_test.go
+++ b/test/e2e/openai_openinference_test.go
@@ -9,19 +9,7 @@ func TestOpenAIOpenInference(t *testing.T) {
 	// No triggerHaiku — the haiku request is issued by make run itself.
 	startCLIApp(t, "openai/openinference")
 
-	// TEMPORARY: drop the gen_ai.operation.name optional check (AR-008) to
-	// exercise the new PR attribute-diff feature against the nightly
-	// baseline on main. Revert before merging.
-	profile := OpenAIProfile
-	var optional []AttributeCheck
-	for _, c := range profile.Optional {
-		if c.RuleID != "AR-008" {
-			optional = append(optional, c)
-		}
-	}
-	profile.Optional = optional
-
-	auditSpanWithMetrics(t, "openai", "openinference", profile,
+	auditSpanWithMetrics(t, "openai", "openinference", OpenAIProfile,
 		`fetch spans, from: now()-10m
 | filter service.name == "openai/openinference"
 | filter isNotNull(gen_ai.request.model)


### PR DESCRIPTION
## Summary
- The PR span-audit comment already lists which \`gen_ai.*\` attributes are present/absent per suite, but didn't call out *changes* — so a newly-broken or newly-available attribute could slip by unnoticed in review.
- Adds a "📊 Attribute changes vs. nightly (\`main\`)" section to the comment that diffs this run's attribute/metric detection status (pass/present vs. fail/absent) against the most recent completed nightly run on \`main\`, listing anything added or removed.
- New scripts: \`download-nightly-baseline.sh\` (fetches the baseline run's artifacts) and \`pr-attribute-diff.sh\` (computes and renders the diff); \`pr-audit-comment.sh\` now includes the section, and the \`pr-audit-comment\` job gets \`actions: read\` to query/download the baseline run.

## Test plan
- [x] Verified the diff logic locally against synthetic fixture reports (added/removed/no-change/no-baseline cases).
- [x] Pushed a temporary commit that dropped the \`gen_ai.operation.name\` (AR-008) optional check from the \`openai/openinference\` suite, to force a real "Removed" case against the nightly baseline. CI ran and the PR comment correctly rendered:
  \`\`\`
  ### 📊 Attribute changes vs. nightly (main)
  Baseline: last nightly run.

  Removed
  | Suite | Attribute | Before | Now |
  |-------|-----------|--------|-----|
  | openai/openinference | gen_ai.operation.name | present | not tracked |
  \`\`\`
- [x] Reverted the temporary commit — this PR now contains only the real feature.